### PR TITLE
Remove references to go_get

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -4,7 +4,7 @@ Go has a strong built-in concept of packages so it's probably a good idea to mat
 rules to Go packages.
 """
 def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = [], visibility:list = ["PUBLIC"],
-                 architectures:list=[], strip_srcs:bool=False, tags:list=None):
+                 architectures:list=[], strip_srcs:bool=True, tags:list=None):
     """
     Downloads Go and exposes :<name>|go and :<name>|gofmt as entry points. To use this rule add the
     following to your .plzconfig:
@@ -25,8 +25,7 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
                             rule will automatically install the arch provided through --arch. This is only useful if you
                             want to manually cross-compile parts of the repo but not others.
       strip_srcs (bool): Whether to strip sources from the SDK which can reduce the size of the cached artifacts and
-                         improve performance, especially for remote execution. This doesn't work with go_get() however
-                         it is recommended to set this to True if you're using go_module() exclusively.
+                         improve performance, especially for remote execution. It's recommended to do this by default.
       tags (bool): Build tags to pass when installing the standard library.
     """
     if url and version:
@@ -1129,9 +1128,6 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
     Note that unlike a normal `go get` call, this does *not* install transitive dependencies.
     You will need to add those as separate rules; `go list -f '{{.Deps}}' <package>` can be
     useful to discover what they should be.
-
-    This rule is different to go_get() in that it is go module aware. It handles vanity imports and major versions
-    correctly so is the recommended approach.
 
     Args:
       name (str): Name of the rule


### PR DESCRIPTION
There's no point since it's not in this plugin any more.

Also set the default for `strip_srcs` to `True` since it mostly seems to have been there for `go_get`.