### PR TITLE
Fix embedding directories by name

### DIFF
--- a/tools/please_go/embed/embed.go
+++ b/tools/please_go/embed/embed.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/build"
 	"io"
+	"io/fs"
 	"path"
 	"path/filepath"
 	"strings"
@@ -82,8 +83,18 @@ func relglob(dir, pattern string) ([]string, error) {
 	if err == nil && len(paths) == 0 {
 		return nil, fmt.Errorf("pattern %s: no matching paths found", pattern)
 	}
-	for i, p := range paths {
-		paths[i] = strings.TrimLeft(strings.TrimPrefix(p, dir), string(filepath.Separator))
+	ret := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if err := filepath.WalkDir(p, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			} else if !d.IsDir() {
+				ret = append(ret, strings.TrimLeft(strings.TrimPrefix(path, dir), string(filepath.Separator)))
+			}
+			return nil
+		}); err != nil {
+			return nil, err
+		}
 	}
-	return paths, err
+	return ret, err
 }

--- a/tools/please_go/embed/embed_test.go
+++ b/tools/please_go/embed/embed_test.go
@@ -12,6 +12,7 @@ func TestParseEmbed(t *testing.T) {
 	assert.Equal(t, map[string][]string{
 		"hello.txt":   {"hello.txt"},
 		"files/*.txt": {"files/test.txt"},
+		"files":       {"files/test.txt"},
 	}, cfg.Patterns)
 	assert.Equal(t, map[string]string{
 		"hello.txt":      "tools/please_go_embed/embed/test_data/hello.txt",

--- a/tools/please_go/embed/test_data/test.go
+++ b/tools/please_go/embed/test_data/test.go
@@ -7,3 +7,6 @@ var hello string
 
 //go:embed files/*.txt
 var txt embed.FS
+
+//go:embed files
+var dir embed.FS


### PR DESCRIPTION
Fix for https://github.com/thought-machine/please/issues/2478; it seems Go expands a directory name to the files within it.