### PR TITLE
Apply check-go-version=false delve flag to either mode of debugging 

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1257,9 +1257,9 @@ def _debug_cmd(name:str, bin:str, flags:str='', pre_cmd:str='', srcs:list=[], de
         return "", None, None
 
     # Delve command.
-    cmd = f"$DEBUG_TOOLS_DLV exec {bin}"
+    cmd = f"$DEBUG_TOOLS_DLV exec {bin} --check-go-version=false"
     if CONFIG.DEBUG_PORT:
-        cmd = f"{cmd} --headless=true --listen=localhost:{CONFIG.DEBUG_PORT} --api-version=2 --check-go-version=false"
+        cmd = f"{cmd} --headless=true --listen=localhost:{CONFIG.DEBUG_PORT} --api-version=2"
     cmd = f"{cmd} -- {flags}"
 
     tools = {


### PR DESCRIPTION
Can't remember why this was only being applied to the server mode (i.e. IDE) but I guess it makes sense it is applied for the CLI as well. This will reduce some friction between different versions of delve and the go binary.