### PR TITLE
Implement an external packages driver

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1112,7 +1112,7 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
             "go": f":{name}", # provide the filegroup otherwise exported deps don't work
             "go_src": download,
         },
-        labels = labels + [f"go_package:{i}" for i in install],
+        labels = labels + [f"go_package:{i}" for i in install] + ["go_module_path:" + module],
         visibility = visibility,
         needs_transitive_deps = True,
         test_only = test_only,

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -86,7 +86,10 @@ go_module(
 
 go_module(
     name = "flags",
-    install = ["flags"],
+    install = [
+        "flags",
+        "logging",
+    ],
     licences = ["Apache-2.0"],
     module = "github.com/peterebden/go-cli-init/v5",
     version = "v5.1.0",
@@ -94,6 +97,9 @@ go_module(
     deps = [
         ":go-flags",
         ":humanize",
+        ":xcrypto",
+        ":logging",
+        ":xsys",
     ],
 )
 
@@ -103,4 +109,65 @@ go_module(
     module = "github.com/cespare/xxhash/v2",
     version = "v2.1.2",
     visibility = ["PUBLIC"],
+)
+
+go_module(
+    name = "xtools",
+    install = [
+        "go/packages",
+        "go/gcexportdata",
+        "go/internal/packagesdriver",
+        "internal/event/...",
+        "internal/pkgbits",
+        "internal/gcimporter",
+        "internal/gocommand",
+        "internal/packagesinternal",
+        "internal/typeparams",
+        "internal/typesinternal",
+    ],
+    licences = ["BSD-3-Clause"],
+    module = "golang.org/x/tools",
+    version = "v0.4.0",
+    deps = [
+        ":xmod",
+        ":xsys",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+go_module(
+    name = "xmod",
+    install = [
+        "semver",
+    ],
+    licences = ["BSD-3-Clause"],
+    module = "golang.org/x/mod",
+    version = "v0.7.0",
+)
+
+go_module(
+    name = "logging",
+    licences = ["BSD-3-Clause"],
+    module = "gopkg.in/op/go-logging.v1",
+    version = "v1.0.0-20160211212156-b2cb9fa56473",
+    deps = [":xcrypto"],
+)
+
+go_module(
+    name = "xcrypto",
+    install = [
+        "ssh/terminal",
+    ],
+    licences = ["BSD-3-Clause"],
+    module = "golang.org/x/crypto",
+    version = "v0.0.0-20210920023735-84f357641f63",
+    deps = [":xterm"],
+)
+
+go_module(
+    name = "xterm",
+    licences = ["BSD-3-Clause"],
+    module = "golang.org/x/term",
+    version = "v0.0.0-20210615171337-6886f2dfbf5b",
+    deps = [":xsys"],
 )

--- a/tools/driver/BUILD
+++ b/tools/driver/BUILD
@@ -1,0 +1,10 @@
+subinclude("//build_defs:go")
+
+go_binary(
+    name = "gopackagesdriver",
+    srcs = ["main.go"],
+    deps = [
+        "//third_party/go:flags",
+        "//tools/driver/packages",
+    ],
+)

--- a/tools/driver/main.go
+++ b/tools/driver/main.go
@@ -16,7 +16,7 @@ var opts = struct {
 	Usage     string
 	Verbosity logging.Verbosity `short:"v" long:"verbosity" default:"warning" description:"Verbosity of output (higher number = more output)"`
 	Args      struct {
-		Packages []string `positional-arg-name:"package" required:"true"`
+		Files []string `positional-arg-name:"file" required:"true"`
 	} `positional-args:"true"`
 }{
 	Usage: `
@@ -37,7 +37,7 @@ func main() {
 	if err := json.NewDecoder(os.Stdin).Decode(req); err != nil {
 		log.Fatalf("Failed to read request: %s", err)
 	}
-	resp, err := packages.Load(req, opts.Args.Packages)
+	resp, err := packages.Load(req, opts.Args.Files)
 	if err != nil {
 		log.Fatalf("Failed to load packages: %s", err)
 	}

--- a/tools/driver/main.go
+++ b/tools/driver/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/peterebden/go-cli-init/v5/flags"
+	"github.com/peterebden/go-cli-init/v5/logging"
+
+	"github.com/please-build/go-rules/tools/driver/packages"
+)
+
+var log = logging.MustGetLogger()
+
+var opts = struct {
+	Usage     string
+	Verbosity logging.Verbosity `short:"v" long:"verbosity" default:"warning" description:"Verbosity of output (higher number = more output)"`
+	Args      struct {
+		Packages []string `positional-arg-name:"package" required:"true"`
+	} `positional-args:"true"`
+}{
+	Usage: `
+This is an implementation of the Go packages driver protocol for Please.
+The protocol is defined by golang.org/x/tools/go/package; typically you specify this binary
+in the GOPACKAGESDRIVER environment variable, and it will then be used in place of go list
+to return information about Go package structure.
+
+This tool is experimental.
+`,
+}
+
+func main() {
+	flags.ParseFlagsOrDie("Please Go package driver", &opts, nil)
+	logging.InitLogging(opts.Verbosity)
+
+	req := &packages.DriverRequest{}
+	if err := json.NewDecoder(os.Stdin).Decode(req); err != nil {
+		log.Fatalf("Failed to read request: %s", err)
+	}
+	resp, err := packages.Load(req, opts.Args.Packages)
+	if err != nil {
+		log.Fatalf("Failed to load packages: %s", err)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	if err := enc.Encode(resp); err != nil {
+		log.Fatalf("Failed to write packages: %s", err)
+	}
+}

--- a/tools/driver/packages/BUILD
+++ b/tools/driver/packages/BUILD
@@ -1,0 +1,11 @@
+subinclude("//build_defs:go")
+
+go_library(
+    name = "packages",
+    srcs = glob(["*.go"], exclude=["*_test.go"]),
+    deps = [
+        "//third_party/go:flags",
+        "//third_party/go:xtools",
+    ],
+    visibility = ["//tools/driver/..."],
+)

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -147,7 +147,13 @@ func handleSubprocessErr(cmd *exec.Cmd, err error) error {
 
 // toResponse converts `plz query print` output to a DriverResponse
 func toResponse(targets map[string]*buildTarget, originalFiles map[string]struct{}) *DriverResponse {
-	resp := &DriverResponse{}
+	resp := &DriverResponse{
+		Sizes: &types.StdSizes{
+			// These are obviously hardcoded. To worry about later.
+			WordSize: 8,
+			MaxAlign: 8,
+		},
+	}
 	m := map[string]*packages.Package{}
 	for label, target := range targets {
 		for _, pkg := range target.ToPackages() {

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -1,0 +1,34 @@
+package packages
+
+import (
+	"fmt"
+	"go/types"
+
+	"github.com/peterebden/go-cli-init/v5/logging"
+	"golang.org/x/tools/go/packages"
+)
+
+var log = logging.MustGetLogger()
+
+// DriverRequest is copied from go/packages; it's the format of config that we get on stdin.
+type DriverRequest struct {
+	Mode       packages.LoadMode `json:"mode"`
+	Env        []string          `json:"env"`
+	BuildFlags []string          `json:"build_flags"`
+	Tests      bool              `json:"tests"`
+	Overlay    map[string][]byte `json:"overlay"`
+}
+
+// DriverResponse is copied from go/packages; it's our response about packages we've loaded.
+type DriverResponse struct {
+	NotHandled bool
+	Sizes      *types.StdSizes
+	Roots      []string `json:",omitempty"`
+	Packages   []*packages.Package
+	GoVersion  int
+}
+
+// Load reads a set of packages and returns information about them.
+func Load(req *DriverRequest, packages []string) (*DriverResponse, error) {
+	return &DriverResponse{}, fmt.Errorf("Not handled")
+}


### PR DESCRIPTION
This is still a bit numpty but seems to be moving roughly in the right direction. Is pretty relevant to us right now because we want to get gosec working which needs something like this.

Notes:
 - Doesn't honour all the flags / config etc. Have left some pertinent TODOs littered about the place.
 - It shells out to plz to get information. This works with the "API" we currently have but would be a lot cooler (and faster) if we had an SDK and could do it in-process.
 - Makes assumptions about the location of the stdlib (gross but seem to have little alternative)
 - Would be quite a bit nicer if we had one plz target per Go package (currently we may have multiple for a `go_module` which kinda sucks). If only someone were working on that...
 - I've fixed a bunch of stuff and think it mostly works; currently getting a bunch of weird messages which make me think something is messing up / overwriting files (there's a lot of weird `redeclared in this block` messages followed by lots of `undeclared name` which looks suspiciously like something has shit all over the top of the file, but haven't figured out what that means yet)

Anyway seems worth getting this up for a review before I spend more time on it.