### PR TITLE
decouple name of binary go_module target from name of installed binary

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -912,7 +912,12 @@ def _go_install_module(name:str, module:str, install:list, src:str, outs:list, d
     ]
 
     if binary:
-        outs = [f'pkg/{CONFIG.OS}_{CONFIG.ARCH}/bin/{name}']
+        # This decouples the name of the target from the name of the installed binary when it's unambiguous what the
+        # output binary should be. This is especially useful when installing a module like
+        # github.com/jstemmer/go-junit-report/v2 which results in a binary called v2 which isn't a very helpful name for
+        # a build target.
+        bin_name = basename(install[0]) if len(install) == 1 else name
+        outs = [f'pkg/{CONFIG.OS}_{CONFIG.ARCH}/bin/{bin_name}']
     else:
         outs = [f'pkg/{CONFIG.OS}_{CONFIG.ARCH}/{out}' for out in _remove_redundant_outs(outs)]
 


### PR DESCRIPTION
Having to match the name of the `go_module` target with the name of the installed binary is normally not that restrictive but this breaks down when the installed binary is in the root of a `v2` (or any other version) module, leaving you needing to name your `go_module` target `"v2"`. 

I've only handled the case where there's one package being installed, so it's unambiguous what the name of the installed binary will be. To solve the case where multiple packages are installed, I guess an `outs` parameter like the `python_wheel` rule provides might be the solution.

This partly addresses #32 