### PR TITLE
introduce back go-junit-report for parsing go test output

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -613,7 +613,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
     )
     cmds, tools = _go_binary_cmds(static=static, definitions=definitions, gcov=cgo)
 
-    test_cmd = f'$TEST {flags} 2>&1 | tee $TMP_DIR/test.results'
+    test_cmd = f'$TEST {flags} 2>&1 | $TOOLS_JUNIT_REPORT -skipped-node-text-location message-attr | tee $RESULTS_FILE'
     worker_cmd = f'$(worker {worker})' if worker else ""
     if worker_cmd:
         test_cmd = f'{worker_cmd} && {test_cmd} '
@@ -646,6 +646,9 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         debug_tools = debug_tools,
         cmd = cmds,
         test_cmd = test_cmd,
+        test_tools = {
+            "junit_report": "//third_party/go:junit_report",
+        },
         debug_cmd = debug_cmd,
         visibility = visibility,
         test_sandbox = sandbox,

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -912,7 +912,12 @@ def _go_install_module(name:str, module:str, install:list, src:str, outs:list, d
     ]
 
     if binary:
-        outs = [f'pkg/{CONFIG.OS}_{CONFIG.ARCH}/bin/{name}']
+        # This decouples the name of the target from the name of the installed binary when it's unambiguous what the
+        # output binary should be. This is especially useful when installing a module like
+        # github.com/jstemmer/go-junit-report/v2 which results in a binary called v2 which isn't a very helpful name for
+        # a build target.
+        bin_name = basename(install[0]) if len(install) == 1 else name
+        outs = [f'pkg/{CONFIG.OS}_{CONFIG.ARCH}/bin/{bin_name}']
     else:
         outs = [f'pkg/{CONFIG.OS}_{CONFIG.ARCH}/{out}' for out in _remove_redundant_outs(outs)]
 

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -613,7 +613,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
     )
     cmds, tools = _go_binary_cmds(static=static, definitions=definitions, gcov=cgo)
 
-    test_cmd = f'$TEST {flags} 2>&1 | $TOOLS_JUNIT_REPORT -skipped-node-text-location message-attr | tee $RESULTS_FILE'
+    test_cmd = f'$TEST {flags} 2>&1 | $TOOLS_JUNIT_REPORT | tee $RESULTS_FILE'
     worker_cmd = f'$(worker {worker})' if worker else ""
     if worker_cmd:
         test_cmd = f'{worker_cmd} && {test_cmd} '

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -45,6 +45,21 @@ go_module(
     visibility = ["PUBLIC"],
 )
 
+go_mod_download(
+    name = "junit_report_download",
+    module = "github.com/marcuscaisey/go-junit-report/v2",
+    version = "b576769f22db5b6a7880775f723c0b29e5a03ac7",
+)
+
+go_module(
+    name = "junit_report",
+    binary = True,
+    download = ":junit_report_download",
+    licences = ["MIT"],
+    module = "github.com/jstemmer/go-junit-report/v2",
+    visibility = ["PUBLIC"],
+)
+
 go_module(
     name = "spew",
     install = ["spew"],

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -48,7 +48,7 @@ go_module(
 go_mod_download(
     name = "junit_report_download",
     module = "github.com/marcuscaisey/go-junit-report/v2",
-    version = "b576769f22db5b6a7880775f723c0b29e5a03ac7",
+    version = "f9f65c7e2eb4a7e4a98b4cc8757772ae1092d211",
 )
 
 go_module(


### PR DESCRIPTION
I tried to stack this PR on top of https://github.com/please-build/go-rules/pull/81, but I think i need to be able to push that branch to this repo to be able to use it as a base for this PR. I'll still leave both open since if both get merged, then we may want to just revert this one (as has happened before). I've commented on the change which is accounted for in the other PR.

---

The test output from `go_test` is currently quite hard to read and also can be inaccurate. 

For example, given this test file:
```go
package foo_test

import (
	"fmt"
	"os"
	"testing"

	"github.com/stretchr/testify/assert"
)

func Test1(t *testing.T) {
	fmt.Fprintln(os.Stdout, "Test1 stdout")
	fmt.Fprintln(os.Stderr, "Test1 stderr")
	assert.Equal(t, 1, 2, "Test1 failure")

	t.Run("Subtest1", func(t *testing.T) {
		fmt.Fprintln(os.Stdout, "Test1/Subtest1 stdout")
		fmt.Fprintln(os.Stderr, "Test1/Subtest1 stderr")
		assert.Equal(t, 1, 2, "Test1/Subtest1 failure")

		t.Run("NestedSubtest", func(t *testing.T) {
			fmt.Fprintln(os.Stdout, "Test1/Subtest1/NestedSubtest stdout")
			fmt.Fprintln(os.Stderr, "Test1/Subtest1/NestedSubtest stderr")
			assert.Equal(t, 1, 2, "Test1/Subtest1/NestedSubtest failure")
		})
	})

	t.Run("Subtest2", func(t *testing.T) {
		fmt.Fprintln(os.Stdout, "Test1/Subtest2 stdout")
		fmt.Fprintln(os.Stderr, "Test1/Subtest2 stderr")
		assert.Equal(t, 1, 2, "Test1/Subtest2 failure")
	})
}

func Test2(t *testing.T) {
	fmt.Fprintln(os.Stdout, "Test2 stdout")
	fmt.Fprintln(os.Stderr, "Test2 stderr")
	assert.Equal(t, 1, 2, "Test2 failure")
}
```

we get the following output:

```
12:34:05.092   ERROR: //foo:test failed
Fail: //foo:test   0 passed   0 skipped   5 failed   0 errored Took 10ms
Failure:  in Test1
Test1/Subtest2 stdout
Test1/Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest2
        	Messages:   	Test1/Subtest2 failure
Standard error:
Test1 stdout
Test1 stderr
    foo_test.go:14: 
        	Error Trace:	foo_test.go:14
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1
        	Messages:   	Test1 failure
Test1/Subtest1 stdout
Test1/Subtest1 stderr
    foo_test.go:19: 
        	Error Trace:	foo_test.go:19
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest1
        	Messages:   	Test1/Subtest1 failure
Test1/Subtest1/NestedSubtest stdout
Test1/Subtest1/NestedSubtest stderr
    foo_test.go:24: 
        	Error Trace:	foo_test.go:24
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest1/NestedSubtest
        	Messages:   	Test1/Subtest1/NestedSubtest failure
Test1/Subtest2 stdout
Test1/Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest2
        	Messages:   	Test1/Subtest2 failure

Failure:  in Test1/Subtest1
Test1/Subtest2 stdout
Test1/Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest2
        	Messages:   	Test1/Subtest2 failure
--- FAIL: Test1 (0.00s)
Failure:  in Test1/Subtest1/NestedSubtest
Test1/Subtest2 stdout
Test1/Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest2
        	Messages:   	Test1/Subtest2 failure
--- FAIL: Test1 (0.00s)
    --- FAIL: Test1/Subtest1 (0.00s)
Failure:  in Test1/Subtest2
Test1/Subtest2 stdout
Test1/Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest2
        	Messages:   	Test1/Subtest2 failure
--- FAIL: Test1 (0.00s)
    --- FAIL: Test1/Subtest1 (0.00s)
        --- FAIL: Test1/Subtest1/NestedSubtest (0.00s)
Failure:  in Test2
Test2 stdout
Test2 stderr
    foo_test.go:38: 
        	Error Trace:	foo_test.go:38
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test2
        	Messages:   	Test2 failure
Standard error:
Test2 stdout
Test2 stderr
    foo_test.go:38: 
        	Error Trace:	foo_test.go:38
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test2
        	Messages:   	Test2 failure

//foo:test 5 tests run in 6ms; 0 passed, 5 failed
    Test1                         FAIL  0s
    Test1/Subtest1                FAIL  0s
    Test1/Subtest1/NestedSubtest  FAIL  0s
    Test1/Subtest2                FAIL  0s
    Test2                         FAIL  0s
1 test target and 5 tests run; 0 passed, 5 failed.
Total time: 50ms real, 10ms compute.
```

There are 5 assertions which fail, however 10 assertion failures are shown. All expected assertions are output under the `Standard error` header and then an assertion failure is also output for each failing test / subtest. However, the assertion failures under each `Failure:  in XXX` header are not the always the correct failures. For `Test1` and its subtests, the failure from `Test/Subtest2` is output under each `Failure:  in XXX` header.

I can see that `go-junit-report` `v0.9.0` (technically a couple of commits after this tag) was introduced to the Please repo in 2020 and then reverted due to it not being able to handle more complex input (https://github.com/thought-machine/please/pull/995). This PR introduces it back, now that the tool seems to have matured a bit. Between `v0.9.0` and `v2.0.0`, 81 test cases have been added and it seems to pass the eye test on the above test file:

```
12:44:52.798   ERROR: //foo:test failed: Failed
Fail: //foo:test   0 passed   0 skipped   5 failed   0 errored Took 10ms
Failure:  in Test1
Failed
Test1 stdout
Test1 stderr
    foo_test.go:14: 
        	Error Trace:	foo_test.go:14
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1
        	Messages:   	Test1 failure
Failure:  in Test1/Subtest1
Failed
Test1/Subtest1 stdout
Test1/Subtest1 stderr
    foo_test.go:19: 
        	Error Trace:	foo_test.go:19
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest1
        	Messages:   	Test1/Subtest1 failure
Failure:  in Test1/Subtest1/NestedSubtest
Failed
Test1/Subtest1/NestedSubtest stdout
Test1/Subtest1/NestedSubtest stderr
    foo_test.go:24: 
        	Error Trace:	foo_test.go:24
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest1/NestedSubtest
        	Messages:   	Test1/Subtest1/NestedSubtest failure
Failure:  in Test1/Subtest2
Failed
Test1/Subtest2 stdout
Test1/Subtest2 stderr
    foo_test.go:31: 
        	Error Trace:	foo_test.go:31
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test1/Subtest2
        	Messages:   	Test1/Subtest2 failure
Failure:  in Test2
Failed
Test2 stdout
Test2 stderr
    foo_test.go:38: 
        	Error Trace:	foo_test.go:38
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	Test2
        	Messages:   	Test2 failure
//foo:test 5 tests run in 10ms; 0 passed, 5 failed
    Test1                         FAIL  0s
    Test1/Subtest1                FAIL  0s
    Test1/Subtest1/NestedSubtest  FAIL  0s
    Test1/Subtest2                FAIL  0s
    Test2                         FAIL  0s
1 test target and 5 tests run; 0 passed, 5 failed.
Total time: 50ms real, 10ms compute.
```

Now, only 5 assertion failures are output and each one is under the correct `Failure:  in XXX` heading. 

The version that i've added to this repo is my fork where i've set the message attribute of the `<skipped>` node correctly so that the reason is output correctly by Please (without this change, the skipped test output looks like `Reason: Skipped` vs `Reason: external_test.go:32: Failing on Alpine currently`). I've made a PR to upstream this: https://github.com/jstemmer/go-junit-report/pull/158.

I'm happy to throw any other test files you can think of at `go-junit-report` to make sure it handles them properly 🙏 