### PR TITLE
Update to Go 1.20

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -4,6 +4,9 @@ Version = 17.0.0-beta.1
 [build]
 hashcheckers = sha256
 
+[buildenv]
+goexperiment = nocoverageredesign
+
 [Plugin "go"]
 GoTool = //third_party/go:toolchain|go
 PleaseGoTool = //tools/please_go:bootstrap

--- a/test/go_test_compat/test_repo/.plzconfig
+++ b/test/go_test_compat/test_repo/.plzconfig
@@ -9,3 +9,6 @@ TestRootCompat = true
 
 [FeatureFlags]
 ExcludeGoRules = true
+
+[buildenv]
+goexperiment = nocoverageredesign

--- a/test/root_test/test_repo/.plzconfig
+++ b/test/root_test/test_repo/.plzconfig
@@ -9,3 +9,6 @@ Target = //plugins:go
 
 [FeatureFlags]
 ExcludeGoRules = true
+
+[buildenv]
+goexperiment = nocoverageredesign

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -15,7 +15,7 @@ go_toolchain(
         "netgo",
         "osusergo",
     ],
-    version = "1.19",
+    version = "1.20.1",
     install_std = True,
 )
 

--- a/tools/please_go/install/toolchain/toolchain_test.go
+++ b/tools/please_go/install/toolchain/toolchain_test.go
@@ -12,5 +12,5 @@ func TestGetVersion(t *testing.T) {
 
 	ver, err := tc.GoMinorVersion()
 	require.NoError(t, err)
-	require.Equal(t, 19, ver)
+	require.Equal(t, 20, ver)
 }


### PR DESCRIPTION
Their coverage redesign stuff needs quite a bit of work to support properly, and I'm not sure it's going to be feasible to support 1.19 and 1.20 transparently. 
This is a quick-and-dirty way of proving that it works; I looked at putting this var in the actual build rules but that turned into a rabbit hole because _everywhere_ has to agree about it and it's too easy to miss an invocation somewhere.