### PR TITLE
Support case-sensitive Go module names

### DIFF
--- a/tools/please_go/goget/go_get.go
+++ b/tools/please_go/goget/go_get.go
@@ -35,7 +35,7 @@ func (g *getter) getGoMod(mod, ver string) (*modfile.File, error) {
 		return modFile, nil
 	}
 
-	file := fmt.Sprintf("%s/%s/@v/%s.mod", g.proxyUrl, strings.ToLower(mod), ver)
+	file := fmt.Sprintf("%s/%s/@v/%s.mod", g.proxyUrl, mod, ver)
 	resp, err := client.Get(file)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
using `strings.ToLower(mod)` removes the ability to support case-sensitive Go modules names, for example `github.com/antlr/antlr4/runtime/Go/antlr` is currently being converted to `github.com/antlr/antlr4/runtime/go/antlr` which returns a 404 with the Go Proxy.

--- 

I haven't tested this, but can't immediately see a reason for lowercasing the `mod`. Please share if so, and I'll try to find a better solution :)