### PR TITLE
Remove tee from test command line

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -651,7 +651,9 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
     )
     cmds, tools = _go_binary_cmds(static=static, definitions=definitions, gcov=cgo)
 
-    test_cmd = f'$TEST {flags} 2>&1 | tee $TMP_DIR/test.results'
+    test_cmd = f'$TEST {flags}'
+    if not CONFIG.GO.COVERAGEREDESIGN:
+        test_cmd += ' | tee $TMP_DIR/test.results'
     worker_cmd = f'$(worker {worker})' if worker else ""
     if worker_cmd:
         test_cmd = f'{worker_cmd} && {test_cmd} '

--- a/tools/please_go/test/write_test_main.go
+++ b/tools/please_go/test/write_test_main.go
@@ -152,6 +152,7 @@ var testMainTmpl = template.Must(template.New("main").Parse(`
 package main
 
 import (
+	_gostdlib_io "io"
 	_gostdlib_os "os"
 	{{if not .Benchmark}}_gostdlib_strings "strings"{{end}}
 	_gostdlib_testing "testing"
@@ -220,6 +221,25 @@ func coverTearDown(coverprofile string, gocoverdir string) (string, error) {
 var testDeps = _gostdlib_testdeps.TestDeps{}
 
 func main() {
+    if resultsFile := _gostdlib_os.Getenv("RESULTS_FILE"); resultsFile != "" {
+        f, err := _gostdlib_os.Create(resultsFile)
+        if err != nil {
+            panic(err)
+        }
+        old := _gostdlib_os.Stdout
+        mw := _gostdlib_io.MultiWriter(f, old)
+        r, w, err := _gostdlib_os.Pipe()
+        if err != nil {
+            panic(err)
+        }
+        go _gostdlib_io.Copy(mw, r)
+        _gostdlib_os.Stdout = w
+        defer func() {
+            _gostdlib_os.Stdout = old
+            w.Close()
+            f.Close()
+        }()
+    }
 {{if .Coverage}}
     coverfile := _gostdlib_os.Getenv("COVERAGE_FILE")
     args := []string{_gostdlib_os.Args[0], "-test.v", "-test.coverprofile", coverfile}


### PR DESCRIPTION
All the redirection and tee stuff is a bit ugly. It's nicer for the test to just handle this itself.

This is really awkward to do with Go because `testing` doesn't let you configure what it writes to, and `os.Stdout` is a `File` not an `io.Writer`. I think it's worth it though.