### PR TITLE
Support for ExportFile in Go packages driver

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -381,18 +381,10 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
 
     # Package info rule for the Go packages driver
     if _generate_pkg_info:
-        flag = '-c' if complete else ''
-        deps += [build_rule(
+        deps += [_go_pkg_info(
             name = name,
-            tag = "pkg_info",
-            tools = [CONFIG.GO.PLEASE_GO_TOOL],
             srcs = srcs + resources,
-            outs = {
-                "pkg_info": [f"_{name}_pkg_info.json"],
-                "exports": [f"_{name}_gc_exports"],
-            },
-            cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}' {flag} -e $OUTS_EXPORTS > $OUTS_PKG_INFO",
-            labels = ["go_pkg_info"],
+            complete = complete,
             test_only = test_only,
         )]
 
@@ -1268,17 +1260,11 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
     outs = []
 
     # Package info rule for the Go packages driver
-    pkg_info = build_rule(
+    pkg_info = _go_pkg_info(
         name = name,
-        tag = "pkg_info",
-        tools = [CONFIG.GO.PLEASE_GO_TOOL],
         srcs = [download],
-        outs = {
-            "pkg_info": [f"_{name}_pkg_info.json"],
-            "exports": [f"_{name}_gc_exports"],
-        },
-        cmd = f'$TOOL m -m {module} -s "$SRCS" -e "$OUTS_EXPORTS" > "$OUTS_PKG_INFO"',
-        labels = ["go_pkg_info"],
+        strip = True,
+        module = module,
         test_only = test_only,
     )
 
@@ -1348,6 +1334,28 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
         requires = ['go'],
         binary = binary,
     )
+
+
+def _go_pkg_info(name:str, srcs:list, strip:bool=False, module:str="", complete:bool=False,
+                 test_only:bool=False):
+    """Internal-only function for generating the pkg_info files"""
+    cflag = '-c' if complete else ''
+    sflag = '-s "$SRCS"' if strip else ''
+    mflag = f'm -m {module}' if module else f"p -i '{CONFIG.GO.IMPORT_PATH}'"
+    return build_rule(
+        name = name,
+        tag = "pkg_info",
+        tools = [CONFIG.GO.PLEASE_GO_TOOL],
+        srcs = srcs,
+        outs = {
+            "pkg_info": [f"_{name}_pkg_info.json"],
+            "exports": [f"_{name}_gc_exports"],
+        },
+        cmd = f'$TOOL {mflag} {sflag} {cflag} -e "$OUTS_EXPORTS" > "$OUTS_PKG_INFO"',
+        labels = ["go_pkg_info"],
+        test_only = test_only,
+    )
+
 
 def _set_go_env():
     if CONFIG.GO.STDLIB:

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1269,8 +1269,11 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
         tag = "pkg_info",
         tools = [CONFIG.GO.PLEASE_GO_TOOL],
         srcs = [download],
-        outs = [f"_{name}_pkg_info.json"],
-        cmd = f'$TOOL m -m {module} -s "$SRCS" > $OUT',
+        outs = {
+            "pkg_info": [f"_{name}_pkg_info.json"],
+            "exports": [f"_{name}_gc_exports"],
+        },
+        cmd = f'$TOOL m -m {module} -s "$SRCS" -e "$OUTS_EXPORTS" > "$OUTS_PKG_INFO"',
         labels = ["go_pkg_info"],
         test_only = test_only,
     )

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -399,11 +399,12 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
     )
 
     # Package info rule for the Go packages driver
-    if _generate_pkg_info and _generate_import_config:
+    if _generate_pkg_info:
         deps += [_go_pkg_info(
             name = name,
             srcs = srcs + resources,
-            importconfig = import_cfg,
+            import_path = import_path,
+            package = package,
             complete = complete,
             test_only = test_only,
         )]
@@ -1357,12 +1358,17 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
     )
 
 
-def _go_pkg_info(name:str, srcs:list, importconfig:str, strip:bool=False,
-                 module:str="", complete:bool=False, test_only:bool=False):
+def _go_pkg_info(name:str, srcs:list, importconfig:str=None, import_path:str="", package:str="",
+                 strip:bool=False, module:str="", complete:bool=False, test_only:bool=False):
     """Internal-only function for generating the pkg_info files"""
     cflag = '-c' if complete else ''
     sflag = '-s "$SRCS_SRCS"' if strip else ''
-    cmd = f'$TOOL m -m {module}' if module else f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}'"
+
+    if module:
+        cmd = f'$TOOL m -m {module}'
+    else:
+        import_path = _get_import_path(package, import_path)
+        cmd = f'$TOOL p -i "{CONFIG.GO.IMPORT_PATH}" -m "{import_path}:$PKG_DIR/{package}.a"'
     return build_rule(
         name = name,
         tag = "pkg_info",

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -148,13 +148,6 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
         tools = [CONFIG.GO.GO_TOOL],
     )
 
-    pkg_info = _go_pkg_info(
-        name = name,
-        srcs = [srcs],
-        stdlib = True,
-        strip = True,
-    )
-
     flags = ''
     suffix = ''
     if tags:
@@ -174,23 +167,30 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
     # We have to take some care to compile this in our working directory and not try to install
     # it to the existing GOROOT, which might not be writable.
     cmds = [
-        'GOROOT="`$TOOL env GOROOT`"',
+        'GOROOT="`$TOOLS_GO env GOROOT`"',
         'cp -r "$GOROOT/src" "$GOROOT/pkg" .',
-        f"GODEBUG=installgoroot=all GOROOT=$TMP_DIR $TOOL install{flags} --trimpath std",
+        f"GODEBUG=installgoroot=all GOROOT=$TMP_DIR $TOOLS_GO install{flags} --trimpath std",
         "rm -rf pkg/tool pkg/include",
         "mv pkg $OUTS_PKG",
         f'SUFFIX="{suffix}"',
         'find "$OUTS_PKG" -name "*.a" | sed -e "s=^$OUTS_PKG/${OS}_${ARCH}${SUFFIX}/==" | sed -e s="\.a$"== | xargs -I{} echo "packagefile {}="$PKG_DIR/$OUTS_PKG"/${OS}_${ARCH}${SUFFIX}/{}.a" | sort -u > $OUTS_IC',
+        '$TOOLS_PLZGO m -m "" -s "$SRCS" --importconfig "$OUTS_IC" > $OUTS_PKG_INFO',
     ]
     return genrule(
         name = name,
+        srcs = {"srcs": [srcs]},
         outs = {
             "pkg": [name + "/pkg"],
             "ic": [f"{name}/{name}.importconfig"],
+            "pkg_info": [name + "/pkg_info.json"],
         },
         cmd = cmds,
-        tools = [CONFIG.GO.GO_TOOL],
-        deps = [pkg_info],
+        tools = {
+            "go": [CONFIG.GO.GO_TOOL],
+            "plzgo": [CONFIG.GO.PLEASE_GO_TOOL],
+        },
+        labels = ["go_pkg_info", "go_stdlib", "go"],
+        output_is_complete = True,
         visibility = visibility,
     )
 
@@ -399,10 +399,11 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
     )
 
     # Package info rule for the Go packages driver
-    if _generate_pkg_info:
+    if _generate_pkg_info and _generate_import_config:
         deps += [_go_pkg_info(
             name = name,
             srcs = srcs + resources,
+            importconfig = import_cfg,
             complete = complete,
             test_only = test_only,
         )]
@@ -1278,15 +1279,6 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
         )
     outs = []
 
-    # Package info rule for the Go packages driver
-    pkg_info = _go_pkg_info(
-        name = name,
-        srcs = [download],
-        strip = True,
-        module = module,
-        test_only = test_only,
-    )
-
     # Gets the expected archive name given a target package
     def archive_name(i):
         base = basename(i)
@@ -1312,7 +1304,7 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
         binary = binary,
         src = download,
         outs = outs,
-        deps = deps + exported_deps + [pkg_info],
+        deps = deps + exported_deps,
         test_only = test_only,
         visibility = visibility,
         licences = licences,
@@ -1334,12 +1326,22 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
         cmd = _generate_pkg_import_cfg_cmd('"$OUT"', '"$PKG_DIR"', True),
         outs = [f'{name}.importconfig'],
     )
+
+    # Package info rule for the Go packages driver
+    pkg_info = _go_pkg_info(
+        name = name,
+        srcs = [download],
+        importconfig = import_config,
+        strip = True,
+        module = module,
+        test_only = test_only,
+    )
     exported_deps = exported_deps + [import_config] if exported_deps else [import_config]
 
     return filegroup(
         name = name,
         srcs = [a_rule],
-        deps = deps,
+        deps = deps + [pkg_info],
         exported_deps = exported_deps,
         provides = {
             "go": f":{name}", # provide the filegroup otherwise exported deps don't work
@@ -1355,28 +1357,22 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
     )
 
 
-def _go_pkg_info(name:str, srcs:list, strip:bool=False, module:str="", complete:bool=False,
-                 test_only:bool=False, stdlib:bool=False):
+def _go_pkg_info(name:str, srcs:list, importconfig:str, strip:bool=False,
+                 module:str="", complete:bool=False, test_only:bool=False):
     """Internal-only function for generating the pkg_info files"""
     cflag = '-c' if complete else ''
-    sflag = '-s "$SRCS"' if strip else ''
-    tools = [CONFIG.GO.PLEASE_GO_TOOL]
-    if stdlib:
-        cmd = '$TOOL m -m ""'
-    elif module:
-        cmd = f'$TOOL m -m {module}'
-    else:
-        cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}'"
+    sflag = '-s "$SRCS_SRCS"' if strip else ''
+    cmd = f'$TOOL m -m {module}' if module else f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}'"
     return build_rule(
         name = name,
         tag = "pkg_info",
         tools = [CONFIG.GO.PLEASE_GO_TOOL],
-        srcs = srcs,
-        outs = {
-            "pkg_info": [f"_{name}_pkg_info.json"],
-            "exports": [f"_{name}_gc_exports"],
+        srcs = {
+            "srcs": srcs,
+            "ic": [importconfig],
         },
-        cmd = f'{cmd} {sflag} {cflag} -e "$OUTS_EXPORTS" > "$OUTS_PKG_INFO"',
+        outs = [f"_{name}_pkg_info.json"],
+        cmd = f'{cmd} {sflag} {cflag} > "$OUTS"',
         labels = ["go_pkg_info"],
         test_only = test_only,
     )

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -139,11 +139,20 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
       tags: Go build tags (e.g. 'osusergo' or 'netgo' are relevant to the stdlib)
       visibility: Visibility of this rule
     """
-    # Need to write package info for the stdlib as well.
+    # Need to write package info for the stdlib as well. This requires the source to be present.
+    srcs = build_rule(
+        name = name,
+        tag = 'srcs',
+        outs = [name + '/src'],
+        cmd = 'cp -r "`$TOOL env GOROOT`/src" "$OUT"',
+        tools = [CONFIG.GO.GO_TOOL],
+    )
+
     pkg_info = _go_pkg_info(
         name = name,
-        srcs = [],
+        srcs = [srcs],
         stdlib = True,
+        strip = True,
     )
 
     flags = ''
@@ -168,15 +177,17 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
         'GOROOT="`$TOOL env GOROOT`"',
         'cp -r "$GOROOT/src" "$GOROOT/pkg" .',
         f"GODEBUG=installgoroot=all GOROOT=$TMP_DIR $TOOL install{flags} --trimpath std",
-        "mkdir $OUT",
         "rm -rf pkg/tool pkg/include",
-        "mv pkg $OUT",
+        "mv pkg $OUTS_PKG",
         f'SUFFIX="{suffix}"',
-        'find "$OUTS" -name "*.a" | sed -e "s=^$OUTS/pkg/${OS}_${ARCH}${SUFFIX}/==" | sed -e s="\.a$"== | xargs -I{} echo "packagefile {}="$PKG_DIR/$OUTS"/pkg/${OS}_${ARCH}${SUFFIX}/{}.a" | sort -u > $OUTS/std.importconfig',
+        'find "$OUTS_PKG" -name "*.a" | sed -e "s=^$OUTS_PKG/${OS}_${ARCH}${SUFFIX}/==" | sed -e s="\.a$"== | xargs -I{} echo "packagefile {}="$PKG_DIR/$OUTS_PKG"/${OS}_${ARCH}${SUFFIX}/{}.a" | sort -u > $OUTS_IC',
     ]
     return genrule(
         name = name,
-        outs = [name],
+        outs = {
+            "pkg": [name + "/pkg"],
+            "ic": [f"{name}/{name}.importconfig"],
+        },
         cmd = cmds,
         tools = [CONFIG.GO.GO_TOOL],
         deps = [pkg_info],
@@ -1351,12 +1362,7 @@ def _go_pkg_info(name:str, srcs:list, strip:bool=False, module:str="", complete:
     sflag = '-s "$SRCS"' if strip else ''
     tools = [CONFIG.GO.PLEASE_GO_TOOL]
     if stdlib:
-        cmd = ' && '.join([
-            'mkdir -p $PKG_DIR',
-            'cp -r "`$TOOLS_GO env GOROOT`/src" "${PKG_DIR}/src"',
-            '$TOOLS_PLZGO m --srcs "${PKG_DIR}/src" -m "" -s "${PKG_DIR}/src"',
-        ])
-        tools = {'plzgo': tools, 'go': [CONFIG.GO.GO_TOOL]}
+        cmd = '$TOOL m -m ""'
     elif module:
         cmd = f'$TOOL m -m {module}'
     else:
@@ -1364,7 +1370,7 @@ def _go_pkg_info(name:str, srcs:list, strip:bool=False, module:str="", complete:
     return build_rule(
         name = name,
         tag = "pkg_info",
-        tools = tools,
+        tools = [CONFIG.GO.PLEASE_GO_TOOL],
         srcs = srcs,
         outs = {
             "pkg_info": [f"_{name}_pkg_info.json"],

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1351,7 +1351,11 @@ def _go_pkg_info(name:str, srcs:list, strip:bool=False, module:str="", complete:
     sflag = '-s "$SRCS"' if strip else ''
     tools = [CONFIG.GO.PLEASE_GO_TOOL]
     if stdlib:
-        cmd = 'SRC="`$TOOLS_GO env GOROOT`/src" && $TOOLS_PLZGO m --srcs "$SRC" -m "" -s "$SRC"'
+        cmd = ' && '.join([
+            'mkdir -p $PKG_DIR',
+            'cp -r "`$TOOLS_GO env GOROOT`/src" "${PKG_DIR}/src"',
+            '$TOOLS_PLZGO m --srcs "${PKG_DIR}/src" -m "" -s "${PKG_DIR}/src"',
+        ])
         tools = {'plzgo': tools, 'go': [CONFIG.GO.GO_TOOL]}
     elif module:
         cmd = f'$TOOL m -m {module}'

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -139,6 +139,13 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
       tags: Go build tags (e.g. 'osusergo' or 'netgo' are relevant to the stdlib)
       visibility: Visibility of this rule
     """
+    # Need to write package info for the stdlib as well.
+    pkg_info = _go_pkg_info(
+        name = name,
+        srcs = [],
+        stdlib = True,
+    )
+
     flags = ''
     suffix = ''
     if tags:
@@ -172,6 +179,7 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
         outs = [name],
         cmd = cmds,
         tools = [CONFIG.GO.GO_TOOL],
+        deps = [pkg_info],
         visibility = visibility,
     )
 
@@ -1337,21 +1345,28 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
 
 
 def _go_pkg_info(name:str, srcs:list, strip:bool=False, module:str="", complete:bool=False,
-                 test_only:bool=False):
+                 test_only:bool=False, stdlib:bool=False):
     """Internal-only function for generating the pkg_info files"""
     cflag = '-c' if complete else ''
     sflag = '-s "$SRCS"' if strip else ''
-    mflag = f'm -m {module}' if module else f"p -i '{CONFIG.GO.IMPORT_PATH}'"
+    tools = [CONFIG.GO.PLEASE_GO_TOOL]
+    if stdlib:
+        cmd = 'SRC="`$TOOLS_GO env GOROOT`/src" && $TOOLS_PLZGO m --srcs "$SRC" -m "" -s "$SRC"'
+        tools = {'plzgo': tools, 'go': [CONFIG.GO.GO_TOOL]}
+    elif module:
+        cmd = f'$TOOL m -m {module}'
+    else:
+        cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}'"
     return build_rule(
         name = name,
         tag = "pkg_info",
-        tools = [CONFIG.GO.PLEASE_GO_TOOL],
+        tools = tools,
         srcs = srcs,
         outs = {
             "pkg_info": [f"_{name}_pkg_info.json"],
             "exports": [f"_{name}_gc_exports"],
         },
-        cmd = f'$TOOL {mflag} {sflag} {cflag} -e "$OUTS_EXPORTS" > "$OUTS_PKG_INFO"',
+        cmd = f'{cmd} {sflag} {cflag} -e "$OUTS_EXPORTS" > "$OUTS_PKG_INFO"',
         labels = ["go_pkg_info"],
         test_only = test_only,
     )

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -381,13 +381,14 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
 
     # Package info rule for the Go packages driver
     if _generate_pkg_info:
+        flag = '-c' if complete else ''
         deps += [build_rule(
             name = name,
             tag = "pkg_info",
             tools = [CONFIG.GO.PLEASE_GO_TOOL],
             srcs = srcs + resources,
             outs = [f"_{name}_pkg_info.json"],
-            cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}' > $OUT",
+            cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}' {flag} > $OUT",
             labels = ["go_pkg_info"],
             test_only = test_only,
         )]

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -387,8 +387,11 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             tag = "pkg_info",
             tools = [CONFIG.GO.PLEASE_GO_TOOL],
             srcs = srcs + resources,
-            outs = [f"_{name}_pkg_info.json"],
-            cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}' {flag} > $OUT",
+            outs = {
+                "pkg_info": [f"_{name}_pkg_info.json"],
+                "exports": [f"_{name}_gc_exports"],
+            },
+            cmd = f"$TOOL p -i '{CONFIG.GO.IMPORT_PATH}' {flag} -e $OUTS_EXPORTS > $OUTS_PKG_INFO",
             labels = ["go_pkg_info"],
             test_only = test_only,
         )]

--- a/tools/driver/BUILD
+++ b/tools/driver/BUILD
@@ -3,11 +3,12 @@ subinclude("//build_defs:go")
 go_binary(
     name = "plz-gopackagesdriver",
     srcs = ["main.go"],
+    visibility = ["PUBLIC"],
     deps = [
         "//third_party/go:flags",
+        "//third_party/go:xtools",
         "//tools/driver/packages",
     ],
-    visibility = ["PUBLIC"],
 )
 
 genrule(

--- a/tools/driver/main.go
+++ b/tools/driver/main.go
@@ -46,6 +46,7 @@ func main() {
 		if err := json.NewDecoder(os.Stdin).Decode(req); err != nil {
 			log.Fatalf("Failed to read request: %s", err)
 		}
+		log.Debug("Received driver request: %v", req)
 	}
 	resp, err := packages.Load(req, opts.Args.Files)
 	if err != nil {

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -225,7 +225,7 @@ func loadPackageInfo(files []string, needExportFile bool) ([]*packages.Package, 
 				if needExportFile {
 					// We've got the export file on disk neighbouring the .json file
 					// This 'just knows about' the filenames we define in go.build_defs
-					pkg.ExportFile = filepath.Join(strings.TrimSuffix(file, "_pkg_info.json")+"_gc_exports", pkg.Name)
+					pkg.ExportFile = filepath.Join(strings.TrimSuffix(file, "_pkg_info.json")+"_gc_exports", pkg.PkgPath+".gc")
 				}
 			}
 			lock.Lock()

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -93,13 +93,14 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 	for _, file := range relFiles {
 		dirs[filepath.Dir(file)] = struct{}{}
 	}
-	pkgs, err := loadPackageInfo(relFiles, (req.Mode&packages.NeedExportFile) != 0)
+	pkgs, err := loadPackageInfo(relFiles, req.Mode >= packages.NeedExportFile)
 	if err != nil {
 		return nil, err
 	}
 	// Build the set of root packages
 	seenRoots := map[string]struct{}{}
 	roots := []string{}
+	seenRuntime := false
 	for _, pkg := range pkgs {
 		for _, file := range pkg.GoFiles {
 			if _, present := dirs[filepath.Dir(file)]; present {
@@ -107,6 +108,9 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 					seenRoots[pkg.ID] = struct{}{}
 					roots = append(roots, pkg.ID)
 				}
+			}
+			if pkg.ID == "runtime" {
+				seenRuntime = true
 			}
 		}
 	}
@@ -126,10 +130,15 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 		pkg.CompiledGoFiles = pkg.GoFiles
 		pkg.ExportFile = filepath.Join(rootpath, pkg.ExportFile)
 	}
-	// Handle stdlib imports which are not currently done elsewhere.
-	stdlib, err := loadStdlibPackages()
-	if err != nil {
-		return nil, err
+	if !seenRuntime {
+		// Handle stdlib imports if we didn't already find them
+		// TODO(peterebden): Get rid of loading stdlib here once we do v2 and require it to be
+		//                   explicitly defined as a build rule
+		stdlib, err := loadStdlibPackages()
+		if err != nil {
+			return nil, err
+		}
+		pkgs = append(pkgs, stdlib...)
 	}
 	log.Debug("Built package set")
 	return &DriverResponse{
@@ -138,7 +147,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 			WordSize: 8,
 			MaxAlign: 8,
 		},
-		Packages: append(pkgs, stdlib...),
+		Packages: pkgs,
 		Roots:    roots,
 	}, nil
 }

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -124,6 +124,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 			}
 		}
 		pkg.CompiledGoFiles = pkg.GoFiles
+		pkg.ExportFile = filepath.Join(rootpath, "plz-out/gen", pkg.ExportFile)
 	}
 	// Handle stdlib imports which are not currently done elsewhere.
 	stdlib, err := loadStdlibPackages()
@@ -217,6 +218,10 @@ func loadPackageInfo(files []string) ([]*packages.Package, error) {
 			lpkgs := []*packages.Package{}
 			if err := json.NewDecoder(f).Decode(&lpkgs); err != nil {
 				return fmt.Errorf("failed to decode package info from %s: %s", file, err)
+			}
+			// Update the ExportFile paths which are relative
+			for _, pkg := range lpkgs {
+				pkg.ExportFile = filepath.Join(filepath.Dir(file), pkg.ExportFile)
 			}
 			lock.Lock()
 			defer lock.Unlock()

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -124,7 +124,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 			}
 		}
 		pkg.CompiledGoFiles = pkg.GoFiles
-		pkg.ExportFile = filepath.Join(rootpath, "plz-out/gen", pkg.ExportFile)
+		pkg.ExportFile = filepath.Join(rootpath, pkg.ExportFile)
 	}
 	// Handle stdlib imports which are not currently done elsewhere.
 	stdlib, err := loadStdlibPackages()

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/build"
-	"go/token"
 	"go/types"
 	"io"
 	"os"
@@ -17,7 +16,6 @@ import (
 	"github.com/peterebden/go-cli-init/v5/logging"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/term"
-	"golang.org/x/tools/go/gcexportdata"
 	"golang.org/x/tools/go/packages"
 
 	"github.com/please-build/go-rules/tools/please_go/packageinfo"
@@ -95,7 +93,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 	for _, file := range relFiles {
 		dirs[filepath.Dir(file)] = struct{}{}
 	}
-	pkgs, err := loadPackageInfo(relFiles, (req.Mode&packages.NeedTypesInfo) != 0)
+	pkgs, err := loadPackageInfo(relFiles, (req.Mode&packages.NeedExportFile) != 0)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +146,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 // loadPackageInfo loads all the package information by executing Please.
 // A cooler way of handling this in future would be to do this in-process; for that we'd
 // need to define the SDK we keep talking about as a supported programmatic interface.
-func loadPackageInfo(files []string, needTypes bool) ([]*packages.Package, error) {
+func loadPackageInfo(files []string, needExportFile bool) ([]*packages.Package, error) {
 	isTerminal := term.IsTerminal(int(os.Stderr.Fd()))
 	plz := func(args ...string) *exec.Cmd {
 		cmd := exec.Command("plz", args...)
@@ -224,15 +222,10 @@ func loadPackageInfo(files []string, needTypes bool) ([]*packages.Package, error
 			// Update the ExportFile paths which are relative
 			for _, pkg := range lpkgs {
 				pkg.ExportFile = filepath.Join(filepath.Dir(file), pkg.ExportFile)
-				if needTypes {
-					// If we need type info, we need to get it from a neighbouring gc_exports file
+				if needExportFile {
+					// We've got the export file on disk neighbouring the .json file
 					// This 'just knows about' the filenames we define in go.build_defs
-					filename := filepath.Join(strings.TrimSuffix(file, "_pkg_info.json")+"_gc_exports", pkg.Name)
-					if types, err := loadGCExportData(filename, pkg.PkgPath); err != nil {
-						log.Warning("failed to load GC export data: %s", err)
-					} else {
-						pkg.Types = types
-					}
+					pkg.ExportFile = filepath.Join(strings.TrimSuffix(file, "_pkg_info.json")+"_gc_exports", pkg.Name)
 				}
 			}
 			lock.Lock()
@@ -242,17 +235,6 @@ func loadPackageInfo(files []string, needTypes bool) ([]*packages.Package, error
 		})
 	}
 	return pkgs, g.Wait()
-}
-
-func loadGCExportData(filename, pkgPath string) (*types.Package, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	fset := token.NewFileSet()
-	imports := map[string]*types.Package{}
-	return gcexportdata.Read(f, fset, imports, pkgPath)
 }
 
 // loadStdlibPackages returns all the packages from the Go stdlib.

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -93,7 +93,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 	for _, file := range relFiles {
 		dirs[filepath.Dir(file)] = struct{}{}
 	}
-	pkgs, err := loadPackageInfo(relFiles, req.Mode >= packages.NeedExportFile)
+	pkgs, err := loadPackageInfo(relFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func Load(req *DriverRequest, files []string) (*DriverResponse, error) {
 // loadPackageInfo loads all the package information by executing Please.
 // A cooler way of handling this in future would be to do this in-process; for that we'd
 // need to define the SDK we keep talking about as a supported programmatic interface.
-func loadPackageInfo(files []string, needExportFile bool) ([]*packages.Package, error) {
+func loadPackageInfo(files []string) ([]*packages.Package, error) {
 	isTerminal := term.IsTerminal(int(os.Stderr.Fd()))
 	plz := func(args ...string) *exec.Cmd {
 		cmd := exec.Command("plz", args...)

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -228,14 +228,9 @@ func loadPackageInfo(files []string, needExportFile bool) ([]*packages.Package, 
 			if err := json.NewDecoder(f).Decode(&lpkgs); err != nil {
 				return fmt.Errorf("failed to decode package info from %s: %s", file, err)
 			}
-			// Update the ExportFile paths which are relative
+			// Update the ExportFile paths to include the generated prefix
 			for _, pkg := range lpkgs {
-				pkg.ExportFile = filepath.Join(filepath.Dir(file), pkg.ExportFile)
-				if needExportFile {
-					// We've got the export file on disk neighbouring the .json file
-					// This 'just knows about' the filenames we define in go.build_defs
-					pkg.ExportFile = filepath.Join(strings.TrimSuffix(file, "_pkg_info.json")+"_gc_exports", pkg.PkgPath+".gc")
-				}
+				pkg.ExportFile = filepath.Join("plz-out/gen", pkg.ExportFile)
 			}
 			lock.Lock()
 			defer lock.Unlock()

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -157,7 +157,7 @@ func writeExport(dirname string, pkg *packages.Package, tpkg *types.Package) err
 			return fmt.Errorf("failed to parse %s: %w", file, err)
 		}
 	}
-	filename := filepath.Join(dirname, pkg.Name)
+	filename := filepath.Join(dirname, pkg.PkgPath+".gc")
 	if err := os.MkdirAll(filepath.Dir(filename), 0775); err != nil {
 		return fmt.Errorf("failed to make directory: %w", err)
 	}

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -139,7 +139,7 @@ func writeExports(filename string, pkgs []*packages.Package, tree, complete bool
 				imports = append(imports, types.NewPackage(name, filepath.Base(name)))
 			}
 		}
-		//sort.Slice(imports, func(i, j int) bool { return imports[i].Path() < imports[j].Path() })
+		sort.Slice(imports, func(i, j int) bool { return imports[i].Path() < imports[j].Path() })
 		tpkgs[i].SetImports(imports)
 	}
 	for i, pkg := range pkgs {
@@ -164,6 +164,7 @@ func writeExport(filename string, pkg *packages.Package, tpkg *types.Package, tr
 			return fmt.Errorf("failed to make directory: %w", err)
 		}
 	}
+	pkg.ExportFile = filename
 	f, err := os.Create(filename)
 	if err != nil {
 		return fmt.Errorf("failed to create output file: %w", err)

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -132,10 +132,14 @@ func writeExports(filename string, pkgs []*packages.Package, tree, complete bool
 	}
 	for i, pkg := range pkgs {
 		imports := make([]*types.Package, 0, len(pkg.Imports))
-		for imp := range pkg.Imports {
-			imports = append(imports, m[imp])
+		for name := range pkg.Imports {
+			if imp, present := m[name]; present {
+				imports = append(imports, imp)
+			} else {
+				imports = append(imports, types.NewPackage(name, filepath.Base(name)))
+			}
 		}
-		sort.Slice(imports, func(i, j int) bool { return imports[i].Path() < imports[j].Path() })
+		//sort.Slice(imports, func(i, j int) bool { return imports[i].Path() < imports[j].Path() })
 		tpkgs[i].SetImports(imports)
 	}
 	for i, pkg := range pkgs {

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -80,11 +80,13 @@ var opts = struct {
 	PackageInfo struct {
 		ImportPath string `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
 		Pkg        string `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
+		Exports    string `short:"e" long:"exports" description:"File to write gc export info to"`
 	} `command:"package_info" alias:"p" description:"Creates an info file about a Go package"`
 	ModuleInfo struct {
 		ModulePath string `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
 		Strip      string `short:"s" long:"strip" description:"Prefix to strip off package directories"`
 		Srcs       string `long:"srcs" env:"SRCS" required:"true" description:"Source files of the module"`
+		Exports    string `short:"e" long:"exports" description:"File to write gc export info to"`
 	} `command:"module_info" alias:"m" description:"Creates an info file about a series of packages in a go_module"`
 	Generate struct {
 		SrcRoot          string   `short:"r" long:"src_root" description:"The src root of the module to inspect"`
@@ -176,14 +178,14 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, pi.Exports, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.Exports, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -81,6 +81,7 @@ var opts = struct {
 		ImportPath string `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
 		Pkg        string `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
 		Exports    string `short:"e" long:"exports" description:"File to write gc export info to"`
+		Complete   bool   `short:"c" long:"complete" description:"Mark package as complete"`
 	} `command:"package_info" alias:"p" description:"Creates an info file about a Go package"`
 	ModuleInfo struct {
 		ModulePath string `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
@@ -178,14 +179,14 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, pi.Exports, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, pi.Exports, pi.Complete, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.Exports, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.Exports, true, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -78,10 +78,10 @@ var opts = struct {
 		} `positional-args:"true"`
 	} `command:"embed" alias:"f" description:"Filter go sources based on the go build tag rules."`
 	PackageInfo struct {
-		ImportPath   string `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
-		Pkg          string `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
-		ImportConfig string `long:"importconfig" env:"SRCS_IC" description:"Importconfig file for locating gc export data"`
-		Complete     bool   `short:"c" long:"complete" description:"Mark package as complete"`
+		ImportPath string            `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
+		Pkg        string            `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
+		ImportMap  map[string]string `short:"m" long:"import_map" description:"Existing map of imports"`
+		Complete   bool              `short:"c" long:"complete" description:"Mark package as complete"`
 	} `command:"package_info" alias:"p" description:"Creates an info file about a Go package"`
 	ModuleInfo struct {
 		ModulePath   string `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
@@ -179,14 +179,14 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, pi.ImportConfig, pi.Complete, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, "", pi.ImportMap, pi.Complete, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.ImportConfig, true, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.ImportConfig, nil, true, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -78,16 +78,16 @@ var opts = struct {
 		} `positional-args:"true"`
 	} `command:"embed" alias:"f" description:"Filter go sources based on the go build tag rules."`
 	PackageInfo struct {
-		ImportPath string `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
-		Pkg        string `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
-		Exports    string `short:"e" long:"exports" description:"File to write gc export info to"`
-		Complete   bool   `short:"c" long:"complete" description:"Mark package as complete"`
+		ImportPath   string `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
+		Pkg          string `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
+		ImportConfig string `long:"importconfig" env:"SRCS_IC" description:"Importconfig file for locating gc export data"`
+		Complete     bool   `short:"c" long:"complete" description:"Mark package as complete"`
 	} `command:"package_info" alias:"p" description:"Creates an info file about a Go package"`
 	ModuleInfo struct {
-		ModulePath string `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
-		Strip      string `short:"s" long:"strip" description:"Prefix to strip off package directories"`
-		Srcs       string `long:"srcs" env:"SRCS" required:"true" description:"Source files of the module"`
-		Exports    string `short:"e" long:"exports" description:"File to write gc export info to"`
+		ModulePath   string `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
+		Strip        string `short:"s" long:"strip" description:"Prefix to strip off package directories"`
+		Srcs         string `long:"srcs" env:"SRCS_SRCS" required:"true" description:"Source files of the module"`
+		ImportConfig string `long:"importconfig" env:"SRCS_IC" description:"Importconfig file for locating gc export data"`
 	} `command:"module_info" alias:"m" description:"Creates an info file about a series of packages in a go_module"`
 	Generate struct {
 		SrcRoot          string   `short:"r" long:"src_root" description:"The src root of the module to inspect"`
@@ -179,14 +179,14 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, pi.Exports, pi.Complete, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, pi.ImportConfig, pi.Complete, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.Exports, true, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.ImportConfig, true, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0


### PR DESCRIPTION
This seems to do what `golangci-lint` wants. It's just pointing to the full compiled `.a` file - I have another branch that was trying to build its own minimal export data file but it seems to more or less end up that you need to basically compile the whole thing.  That may deserve some separate thought - I've heard mentions of being able to use those for more efficient caching (although that might be tricky, but maybe it is conceptually similar to the C++ rules and how the headers work there, which is sort of cooler in terms of incrementality, albeit more complex).