### PR TITLE
Fix buildinfo for go version

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1425,6 +1425,7 @@ def _go_modinfo(name:str, test_only:bool=False, deps:list):
             'go': [CONFIG.GO_TOOL],
             'plz': [CONFIG.GO.PLEASE_GO_TOOL],
         },
+        env = {'CGO_ENABLED': '1' if CONFIG.GO.CGO_ENABLED else '0'},
         test_only = test_only,
         deps = deps,
         requires = ['modinfo'],

--- a/test/buildinfo/BUILD
+++ b/test/buildinfo/BUILD
@@ -1,0 +1,10 @@
+subinclude("//build_defs:go")
+
+go_test(
+    name = "buildinfo_test",
+    srcs = ["buildinfo_test.go"],
+    data = ["//tools/please_go"],
+    deps = [
+        "//third_party/go:testify",
+    ],
+)

--- a/test/buildinfo/buildinfo_test.go
+++ b/test/buildinfo/buildinfo_test.go
@@ -1,0 +1,16 @@
+package buildinfo_test
+
+import (
+	"debug/buildinfo"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildInfoIsReadable(t *testing.T) {
+	info, err := buildinfo.ReadFile(os.Getenv("DATA"))
+	assert.NoError(t, err)
+	// Don't get into detail here, but there should be _some_ module info available
+	assert.Greater(t, len(info.Deps), 0)
+}

--- a/tools/please_go/modinfo/modinfo.go
+++ b/tools/please_go/modinfo/modinfo.go
@@ -3,6 +3,7 @@
 package modinfo
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"os"
@@ -10,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -51,5 +51,14 @@ func WriteModInfo(goTool, modulePath, pkgPath, buildMode, outputFile string) err
 		return fmt.Errorf("failed to walk modinfo files: %w", err)
 	}
 	sort.Slice(bi.Deps, func(i, j int) bool { return bi.Deps[i].Path < bi.Deps[j].Path })
-	return os.WriteFile(outputFile, []byte("modinfo "+strconv.Quote(bi.String())+"\n"), 0644)
+	return os.WriteFile(outputFile, []byte(fmt.Sprintf("modinfo %q\n", modInfoData(bi.String()))), 0644)
+}
+
+// modInfoData wraps the given string in Go's modinfo. This mimics what go build does in order
+// for `go version` to be able to find this lot later on.
+func modInfoData(modinfo string) string {
+	// These are not exported from the stdlib (they're in cmd/go/internal/modload) so we must duplicate :(
+	start, _ := hex.DecodeString("3077af0c9274080241e1c107e6d618e6")
+	end, _ := hex.DecodeString("f932433186182072008242104116d8f2")
+	return string(start) + modinfo + string(end)
 }

--- a/tools/please_go/modinfo/modinfo.go
+++ b/tools/please_go/modinfo/modinfo.go
@@ -15,7 +15,10 @@ import (
 )
 
 // WriteModInfo writes mod info to the given output file
-func WriteModInfo(goTool, modulePath, pkgPath, buildMode, outputFile string) error {
+func WriteModInfo(goTool, modulePath, pkgPath, buildMode, cgoEnabled, goos, goarch, outputFile string) error {
+	if buildMode == "" {
+		buildMode = "exe"
+	}
 	// Nab the Go version from the tool
 	out, err := exec.Command(goTool, "version").CombinedOutput()
 	if err != nil {
@@ -30,6 +33,9 @@ func WriteModInfo(goTool, modulePath, pkgPath, buildMode, outputFile string) err
 		},
 		Settings: []debug.BuildSetting{
 			{Key: "-buildmode", Value: buildMode},
+			{Key: "CGO_ENABLED", Value: cgoEnabled},
+			{Key: "GOARCH", Value: goarch},
+			{Key: "GOOS", Value: goos},
 		},
 	}
 	if err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -114,6 +114,9 @@ var opts = struct {
 		BuildMode  string `short:"b" long:"build_mode" default:"exe" description:"The Go build mode being used"`
 		Out        string `short:"o" long:"out" env:"OUT" required:"true" description:"File to write the output to"`
 		Write      bool   `short:"w" long:"write" hidden:"true" description:"Print this binary's own modinfo"`
+		CgoEnabled string `short:"c" long:"cgo_enabled" env:"CGO_ENABLED" description:"Whether cgo is enabled or not"`
+		GoOS       string `long:"goos" env:"OS" description:"OS we're compiling for"`
+		GoArch     string `long:"goarch" env:"ARCH" description:"Architecture we're compiling for"`
 	} `command:"modinfo" description:"Generates Go modinfo for the linter"`
 }{
 	Usage: `
@@ -210,7 +213,7 @@ var subCommands = map[string]func() int{
 			}
 			os.Stderr.Write([]byte(info.String() + "\n"))
 		}
-		if err := modinfo.WriteModInfo(mi.GoTool, mi.ModulePath, filepath.Join(mi.ModulePath, mi.Pkg), mi.BuildMode, mi.Out); err != nil {
+		if err := modinfo.WriteModInfo(mi.GoTool, mi.ModulePath, filepath.Join(mi.ModulePath, mi.Pkg), mi.BuildMode, mi.CgoEnabled, mi.GoOS, mi.GoArch, mi.Out); err != nil {
 			log.Fatalf("failed to write modinfo: %s", err)
 		}
 		return 0


### PR DESCRIPTION
Before: 
```
$ go version -m plz-out/bin/tools/please_go/please_go
plz-out/bin/tools/please_go/please_go: go1.20.3
```
Now:
```
$ go version -m plz-out/bin/tools/please_go/please_go
plz-out/bin/tools/please_go/please_go: go1.20.3
	path	github.com/please-build/go-rules/tools/please_go
	mod	github.com/please-build/go-rules		
	dep	github.com/dustin/go-humanize	v1.0.0	
	dep	github.com/peterebden/buildtools	ce40803f44fb09c5cf60b5554fe5819d02df23fc	
	dep	github.com/peterebden/go-cli-init/v5	v5.1.0	
	dep	github.com/thought-machine/go-flags	v1.6.0	
	dep	golang.org/x/crypto	v0.0.0-20210920023735-84f357641f63	
	dep	golang.org/x/mod	v0.5.0	
	dep	golang.org/x/sys	039c03cc5b867cd7b06a19ff375be5c945c80b10	
	dep	golang.org/x/term	v0.0.0-20210615171337-6886f2dfbf5b	
	dep	golang.org/x/tools	v0.4.0	
	dep	golang.org/x/xerrors	v0.0.0-20200804184101-5ec99f83aff1	
	dep	gopkg.in/op/go-logging.v1	v1.0.0-20160211212156-b2cb9fa56473	
	build	-buildmode=exe
	build	CGO_ENABLED=0
	build	GOARCH=amd64
	build	GOOS=linux
```
Seems it needs to be wrapped with some weird undocumented gubbins; `debug.ReadBuildInfo` manages ok but `go version` doesn't (it needs to access it quite differently and doesn't seem happy without these bits).