### PR TITLE
Support setting GOAMD64

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -82,7 +82,7 @@ Help = Changes the test working directory to be the package to be more inline wi
 [PluginConfig "cpp_coverage"]
 Type = bool
 DefaultValue = false
-Help = Whether to build C components with coverage 
+Help = Whether to build C components with coverage
 
 [PluginConfig "c_flags"]
 Inherit = true
@@ -131,6 +131,11 @@ Type = bool
 DefaultValue = false
 Optional = true
 Help = Compile for the Go race detector
+
+[PluginConfig "goamd64"]
+DefaultValue = "v1"
+Inherit = true
+Help = Value to set for GOAMD64, determining what era of CPU to target.
 
 [Plugin "shell"]
 Target = //plugins:shell

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -97,6 +97,7 @@ def _go_toolchain(name:str, srcs:list, copy_cmd:str, visibility:list, architectu
           "CC": [CONFIG.GO.CC_TOOL],
         } if CONFIG.GO.CGO_ENABLED == "1" else {},
         binary = True,
+        env = {'GOAMD64': CONFIG.GO.GOAMD64},
         visibility = visibility,
         building_description = "Installing...",
     )

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -192,6 +192,7 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
             "GOARCH": CONFIG.ARCH,
             "GODEBUG": "installgoroot=all",
             "CGO_ENABLED": CONFIG.GO.CGO_ENABLED,
+            "GOAMD64": CONFIG.GO.GOAMD64,
         },
         labels = ["go_pkg_info", "go_stdlib", "go"],
         output_is_complete = True,
@@ -446,6 +447,7 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
         requires = ['go'],
         provides = provides,
         labels = labels+link_labels + [f"go_package:{package_path}"] if _generate_import_config else [],
+        env = {"GOAMD64": CONFIG.GO.GOAMD64},
         test_only = test_only,
         tools = tools,
         needs_transitive_deps = _needs_transitive_deps,
@@ -597,6 +599,7 @@ def go_binary(name:str, srcs:list=[], resources:list=None, asm_srcs:list=[], out
         provides={
             'go': lib,
         },
+        env = {'GOAMD64': CONFIG.GO.GOAMD64},
         pre_build=_collect_linker_flags(static, definitions),
         stamp = stamp,
     )
@@ -635,7 +638,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
             flags:str='', sandbox:bool=None, cgo:bool=False, filter_srcs:bool=True,
             external:bool=False, timeout:int=0, flaky:bool|int=0, test_outputs:list=[],
             labels:list&features&tags=[], size:str=None, static:bool=CONFIG.GO.DEFAULT_STATIC,
-            definitions:str|list|dict=None, env:dict=None):
+            definitions:str|list|dict=None, env:dict={}):
     """Defines a Go test rule.
 
     Args:
@@ -792,7 +795,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         needs_transitive_deps = True,
         output_is_complete = True,
         pre_build = _collect_linker_flags(static, definitions),
-        env = env,
+        env = env | {'GOAMD64': CONFIG.GO.GOAMD64},
     )
 
 
@@ -908,6 +911,7 @@ def go_benchmark(name:str, srcs:list, data:list|dict=None, deps:list=[], visibil
         output_is_complete=True,
         test_only=test_only,
         pre_build = _collect_linker_flags(static, definitions),
+        env = {'GOAMD64': CONFIG.GO.GOAMD64},
     )
 
 def go_test_main(name:str, srcs:list, test_package:str="", test_only:bool=False, external=False,
@@ -1085,7 +1089,7 @@ def _go_install_module(name:str, module:str, install:list, src:str, outs:list, d
         needs_transitive_deps = True,
         licences = licences,
         post_build = _add_ld_flags,
-        env = env,
+        env = env | {'GOAMD64': CONFIG.GO.GOAMD64},
     )
 
 def _add_ld_flags(name:str, stdout:list):
@@ -1425,7 +1429,10 @@ def _go_modinfo(name:str, test_only:bool=False, deps:list):
             'go': [CONFIG.GO_TOOL],
             'plz': [CONFIG.GO.PLEASE_GO_TOOL],
         },
-        env = {'CGO_ENABLED': '1' if CONFIG.GO.CGO_ENABLED else '0'},
+        env = {
+            'CGO_ENABLED': '1' if CONFIG.GO.CGO_ENABLED else '0',
+            'GOAMD64': CONFIG.GO.GOAMD64,
+        },
         test_only = test_only,
         deps = deps,
         requires = ['modinfo'],

--- a/tools/please_go/modinfo/modinfo.go
+++ b/tools/please_go/modinfo/modinfo.go
@@ -15,7 +15,7 @@ import (
 )
 
 // WriteModInfo writes mod info to the given output file
-func WriteModInfo(goTool, modulePath, pkgPath, buildMode, cgoEnabled, goos, goarch, outputFile string) error {
+func WriteModInfo(goTool, modulePath, pkgPath, buildMode, cgoEnabled, goos, goarch, goamd64, outputFile string) error {
 	if buildMode == "" {
 		buildMode = "exe"
 	}
@@ -37,6 +37,10 @@ func WriteModInfo(goTool, modulePath, pkgPath, buildMode, cgoEnabled, goos, goar
 			{Key: "GOARCH", Value: goarch},
 			{Key: "GOOS", Value: goos},
 		},
+	}
+	// Only set GOAMD64 if we are targeting AMD64 #smart
+	if goarch == "amd64" {
+		bi.Settings = append(bi.Settings, debug.BuildSetting{Key: "GOAMD64", Value: goamd64})
 	}
 	if err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".modinfo") {

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -117,6 +117,7 @@ var opts = struct {
 		CgoEnabled string `short:"c" long:"cgo_enabled" env:"CGO_ENABLED" description:"Whether cgo is enabled or not"`
 		GoOS       string `long:"goos" env:"OS" description:"OS we're compiling for"`
 		GoArch     string `long:"goarch" env:"ARCH" description:"Architecture we're compiling for"`
+		GoAMD64    string `long:"goamd64" env:"GOAMD64" description:"GOAMD64 target"`
 	} `command:"modinfo" description:"Generates Go modinfo for the linter"`
 }{
 	Usage: `
@@ -213,7 +214,7 @@ var subCommands = map[string]func() int{
 			}
 			os.Stderr.Write([]byte(info.String() + "\n"))
 		}
-		if err := modinfo.WriteModInfo(mi.GoTool, mi.ModulePath, filepath.Join(mi.ModulePath, mi.Pkg), mi.BuildMode, mi.CgoEnabled, mi.GoOS, mi.GoArch, mi.Out); err != nil {
+		if err := modinfo.WriteModInfo(mi.GoTool, mi.ModulePath, filepath.Join(mi.ModulePath, mi.Pkg), mi.BuildMode, mi.CgoEnabled, mi.GoOS, mi.GoArch, mi.GoAMD64, mi.Out); err != nil {
 			log.Fatalf("failed to write modinfo: %s", err)
 		}
 		return 0


### PR DESCRIPTION
This adds a config setting allowing overriding the AMD64 target.

Have tested flipping back and forth between v1 and v3 and it seems fine (once I added the env var to _everything_)