### PR TITLE
Refactor `please_go` download test to avoid subrepo references

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,28 +1,36 @@
 VERSION = "1.4.1"
 
-remote_file(
+hashes = {
+    "darwin_amd64": "39ba7a7478c16306c7758e81aa53d7ff2908894a8fbc31b1809c2ede7950911e",
+    "darwin_arm64": "342a23306fca55ec7c3c56ccc96af8e61131897c5ba9c245d2d6c4bc293ee1fd",
+    "freebsd_amd64": "5273e338aa07f2f2b1a68a08a14acebee52f8a9758f209b0c9deb7cc0a3b90f4",
+    "linux_amd64": "beb961aec753e4e9b819e8ab259c30c019229903e27f51b5095322b8c9c0ada7",
+    "linux_arm64": "1644712fa35b076b7d4b65e4e250fe9a2c01516561841aa362568f3a26f4f0d2",
+}
+
+binaries = [
+    remote_file(
+        name = tag("please_go", a),
+        binary = True,
+        hashes = [h],
+        labels = ["manual"],  # Needed to avoid picking this up for coverage
+        url = f"https://github.com/please-build/go-rules/releases/download/please-go-v{VERSION}/please_go-{VERSION}-{a}",
+    )
+    for a, h in hashes.items()
+]
+
+build_rule(
     name = "please_go",
+    srcs = [":" + tag("please_go", f"{CONFIG.OS}_{CONFIG.ARCH}")],
+    outs = [f"please_go-{VERSION}"],
     binary = True,
-    hashes = [
-        "39ba7a7478c16306c7758e81aa53d7ff2908894a8fbc31b1809c2ede7950911e",  # please_go-1.4.1-darwin_amd64
-        "342a23306fca55ec7c3c56ccc96af8e61131897c5ba9c245d2d6c4bc293ee1fd",  # please_go-1.4.1-darwin_arm64
-        "5273e338aa07f2f2b1a68a08a14acebee52f8a9758f209b0c9deb7cc0a3b90f4",  # please_go-1.4.1-freebsd_amd64
-        "beb961aec753e4e9b819e8ab259c30c019229903e27f51b5095322b8c9c0ada7",  # please_go-1.4.1-linux_amd64
-        "1644712fa35b076b7d4b65e4e250fe9a2c01516561841aa362568f3a26f4f0d2",  # please_go-1.4.1-linux_arm64
-    ],
+    cmd = "cp $SRCS $OUTS",
     labels = ["manual"],  # Needed to avoid picking this up for coverage
-    url = f"https://github.com/please-build/go-rules/releases/download/please-go-v{VERSION}/please_go-{VERSION}-{CONFIG.OS}_{CONFIG.ARCH}",
     visibility = ["PUBLIC"],
 )
 
 filegroup(
     name = "download_test",
-    srcs = [
-        "///darwin_amd64//tools:please_go",
-        "///darwin_arm64//tools:please_go",
-        "///freebsd_amd64//tools:please_go",
-        "///linux_amd64//tools:please_go",
-        "///linux_arm64//tools:please_go",
-    ],
+    srcs = binaries,
     labels = ["manual"],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -8,29 +8,13 @@ hashes = {
     "linux_arm64": "1644712fa35b076b7d4b65e4e250fe9a2c01516561841aa362568f3a26f4f0d2",
 }
 
-binaries = [
+for a, h in hashes.items():
+    native = f"{CONFIG.OS}_{CONFIG.ARCH}" == a
     remote_file(
-        name = tag("please_go", a),
+        name = "please_go" if native else f"please_go_{a}",
         binary = True,
         hashes = [h],
-        labels = ["manual"],  # Needed to avoid picking this up for coverage
+        labels = None if native else ["manual"],  # Needed to avoid picking this up for other architectures for coverage
         url = f"https://github.com/please-build/go-rules/releases/download/please-go-v{VERSION}/please_go-{VERSION}-{a}",
+        visibility = ["PUBLIC"] if native else None,
     )
-    for a, h in hashes.items()
-]
-
-build_rule(
-    name = "please_go",
-    srcs = [":" + tag("please_go", f"{CONFIG.OS}_{CONFIG.ARCH}")],
-    outs = [f"please_go-{VERSION}"],
-    binary = True,
-    cmd = "cp $SRCS $OUTS",
-    labels = ["manual"],  # Needed to avoid picking this up for coverage
-    visibility = ["PUBLIC"],
-)
-
-filegroup(
-    name = "download_test",
-    srcs = binaries,
-    labels = ["manual"],
-)


### PR DESCRIPTION
The architecture-specific subrepo references in `//tools:download_test` aren't meaningful outside the go-rules repo, causing `plz query graph` to fail with the following error in any parent repo that includes go-rules:

```
CRITICAL: Target ///darwin_amd64//tools:please_go not found in build graph
```

Refactor the downloading of `please_go` and the download test to avoid making subrepo references that might not exist in other contexts.

Fixes #135.