### PR TITLE
fix: dont check toolchain version when version is not provided

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -45,7 +45,7 @@ def go_toolchain(name:str, url:str|dict = '', version:str = '', hashes:list = []
         hashes = hashes,
     )
 
-    if semver_check(version, ">= 1.20.0") and install_std is None:
+    if version != "" and semver_check(version, ">= 1.20.0") and install_std is None:
         install_std = True
 
     return _go_toolchain(


### PR DESCRIPTION
When an `url` is provided, we cannot set a version. But `semver_check()` fail if the version is empty.

Just skip the version check and let the user set `install_std` if needed for it go toolchain version.