### PR TITLE
Remove implicit dependency on GCC toolchain

### DIFF
--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -38,7 +38,7 @@ def cgo_library(name:str, srcs:list=[], resources:list=None, go_srcs:list=[], c_
     assert srcs or go_srcs, 'At least one of srcs and go_srcs must be provided'
 
     if CONFIG.BUILD_CONFIG == "cover":
-        linker_flags += ["-lgcov"]
+        linker_flags += ["--coverage"]
 
     if not srcs:
         return go_library(

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1583,7 +1583,7 @@ def _go_binary_cmds(static=False, ldflags='', pkg_config='', definitions=None, g
         'opt': f'{gen_import_cfg} && {_link_cmd} {flags} -s -w $SRCS',
     }
     if gcov and CONFIG.GO.CPP_COVERAGE:
-        cmds['cover'] = f'{gen_import_cfg} && {_link_cmd} {flags} -extldflags="-lgcov" $SRCS'
+        cmds['cover'] = f'{gen_import_cfg} && {_link_cmd} {flags} -extldflags="--coverage" $SRCS'
 
     return cmds, {
         'go': [CONFIG.GO.GO_TOOL],


### PR DESCRIPTION
gcov is part of the GCC toolchain - rather than explicitly linking to libgcov in the coverage profile, pass the `--coverage` flag to the compiler toolchain (which is recognised by both GCC and LLVM).