### PR TITLE
Add modinfo to go_repo actions

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -221,7 +221,7 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
                _needs_transitive_deps=False, _all_srcs=False, cover:bool=True,
                filter_srcs:bool=True, _link_private:bool=False, _link_extra:bool=True, _abi:str=None,
                _generate_import_config:bool=True, _generate_pkg_info:bool=CONFIG.GO.PKG_INFO,
-               import_path:str='', labels:list=[], package:str=None, pgo_file:str=None):
+               import_path:str='', labels:list=[], package:str=None, pgo_file:str=None, _module:str=''):
     """Generates a Go library which can be reused by other rules.
 
     Args:
@@ -254,6 +254,25 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
     src_labels = []
     private = out.startswith('_')
     package_path = _get_import_path(package, import_path)
+
+    if _module:
+        # We're in a module, create a modinfo file identifying it
+        modinfo = build_rule(
+            name = name,
+            tag = "modinfo",
+            outs = [f"_{name}.modinfo"],
+            cmd = f"echo '{_module}' > $OUT",
+        )
+    else:
+        # Dummy modinfo so we don't have to provide everything for binary modinfo actions.
+        modinfo = filegroup(
+            name = name,
+            tag = "modinfo",
+            deps = deps,
+            requires = ["modinfo"],
+            test_only = test_only,
+        )
+    deps += [modinfo]
 
     # We could just depend on go_src for all our deps but that would mean bringing in srcs for targets outside this
     # package like third party sources which is especially slow on systems with slow syscall performance (macOS)
@@ -1100,8 +1119,9 @@ def _add_ld_flags(name:str, stdout:list):
 def _module_rule_name(module):
     return module.replace("/", "_")
 
-def go_repo(module: str, version:str=None, download:str=None, name:str=None, install:list=[], requirements:list=[],
-        licences=None, patch=None, visibility=["PUBLIC"]):
+
+def go_repo(module: str, version:str='', download:str=None, name:str=None, install:list=[], requirements:list=[],
+            licences:list=None, patch:list=None, visibility:list=["PUBLIC"]):
     """Adds a third party go module to the build graph as a subrepo. This is designed to be closer to how the `go.mod`
     file works, requiring only the module name and version to be specified. Unlike go_module, each package is compiled
     individually, and dependencies between packages are inferred by convention.
@@ -1166,7 +1186,7 @@ def go_repo(module: str, version:str=None, download:str=None, name:str=None, ins
         name = name,
         tag = "repo" if install else None,
         srcs =  srcs,
-        cmd  = f"rm -rf $SRCS_DOWNLOAD/.plzconfig && find $SRCS_DOWNLOAD -name BUILD -delete && $TOOL generate {modFileArg} --module {module} --src_root=$SRCS_DOWNLOAD {install_args} {requirements} && mv $SRCS_DOWNLOAD $OUT",
+        cmd  = f"rm -rf $SRCS_DOWNLOAD/.plzconfig && find $SRCS_DOWNLOAD -name BUILD -delete && $TOOL generate {modFileArg} --module {module} --version '{version}' --src_root=$SRCS_DOWNLOAD {install_args} {requirements} && mv $SRCS_DOWNLOAD $OUT",
         outs = [subrepo_name],
         tools = [CONFIG.GO.PLEASE_GO_TOOL],
         env= {

--- a/tools/please_go/generate/generate.go
+++ b/tools/please_go/generate/generate.go
@@ -15,6 +15,7 @@ import (
 
 type Generate struct {
 	moduleName         string
+	moduleArg          string
 	srcRoot            string
 	buildContext       build.Context
 	modFile            string
@@ -27,7 +28,11 @@ type Generate struct {
 	install            []string
 }
 
-func New(srcRoot, thirdPartyFolder, modFile, module string, buildFileNames, moduleDeps, install []string) *Generate {
+func New(srcRoot, thirdPartyFolder, modFile, module, version string, buildFileNames, moduleDeps, install []string) *Generate {
+	moduleArg := module
+	if version != "" {
+		moduleArg += "@" + version
+	}
 	return &Generate{
 		srcRoot:            srcRoot,
 		buildContext:       build.Default,
@@ -38,6 +43,7 @@ func New(srcRoot, thirdPartyFolder, modFile, module string, buildFileNames, modu
 		thirdPartyFolder:   thirdPartyFolder,
 		install:            install,
 		moduleName:         module,
+		moduleArg:          moduleArg,
 	}
 }
 
@@ -341,6 +347,7 @@ func (g *Generate) libRule(pkg *build.Package, dir string) *Rule {
 		name:          name,
 		kind:          packageKind(pkg),
 		srcs:          pkg.GoFiles,
+		module:        g.moduleArg,
 		cgoSrcs:       pkg.CgoFiles,
 		compilerFlags: pkg.CgoCFLAGS,
 		linkerFlags:   pkg.CgoLDFLAGS,

--- a/tools/please_go/generate/rules.go
+++ b/tools/please_go/generate/rules.go
@@ -5,6 +5,7 @@ import "github.com/bazelbuild/buildtools/build"
 type Rule struct {
 	name          string
 	kind          string
+	module        string
 	srcs          []string
 	cgoSrcs       []string
 	compilerFlags []string
@@ -54,4 +55,5 @@ func populateRule(r *build.Rule, targetState *Rule) {
 			},
 		})
 	}
+	r.SetAttr("_module", NewStringExpr(targetState.module))
 }

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -97,6 +97,7 @@ var opts = struct {
 		ThirdPartyFolder string   `short:"t" long:"third_part_folder" description:"The folder containing the third party subrepos" default:"third_party/go"`
 		ModFile          string   `long:"mod_file" description:"Path to the mod file to use to resolve dependencies against"`
 		Module           string   `long:"module" description:"The name of the current module"`
+		Version          string   `long:"version" description:"The version of the current module"`
 		Install          []string `long:"install" description:"The packages to add to the :install alias"`
 		Args             struct {
 			Requirements []string `positional-arg-name:"requirements" description:"Any module requirements not included in the go.mod"`
@@ -173,7 +174,7 @@ var subCommands = map[string]func() int{
 		return 0
 	},
 	"generate": func() int {
-		g := generate.New(opts.Generate.SrcRoot, opts.Generate.ThirdPartyFolder, opts.Generate.ModFile, opts.Generate.Module, []string{"BUILD", "BUILD.plz"}, opts.Generate.Args.Requirements, opts.Generate.Install)
+		g := generate.New(opts.Generate.SrcRoot, opts.Generate.ThirdPartyFolder, opts.Generate.ModFile, opts.Generate.Module, opts.Generate.Version, []string{"BUILD", "BUILD.plz"}, opts.Generate.Args.Requirements, opts.Generate.Install)
 		if err := g.Generate(); err != nil {
 			log.Fatalf("failed to generate go rules: %v", err)
 		}


### PR DESCRIPTION
These are a bit trickier because they generate `go_library`s which don't directly depend on anything central to attach this to, so we generate one for each of them.