### PR TITLE
Update plz version & add subinclude

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-Version = >=17.0.0-beta.8
+Version = >=17.2.0
 
 [build]
 hashcheckers = sha256

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "e2e",
     plugin = "plugin-integration-testing",
-    revision="v1.0.1"
+    revision="b9b913ed4b13aac4b921e70c716fca6615eb681a"
 )
 
 plugin_repo(

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "e2e",
     plugin = "plugin-integration-testing",
-    revision="b9b913ed4b13aac4b921e70c716fca6615eb681a"
+    revision="v1.0.2"
 )
 
 plugin_repo(

--- a/test/goget/BUILD
+++ b/test/goget/BUILD
@@ -1,4 +1,4 @@
-subinclude("//test/build_defs:e2e")
+subinclude("///shell//build_defs:shell", "//test/build_defs:e2e")
 
 please_repo_e2e_test(
     name = "go_get_test",


### PR DESCRIPTION
This fixes the build in `//test/goget:go_get_test` on recent plz versions.

I'm not sure precisely what's happening but it seems wrong; it works in 17.0.0 but in 17.2.0 that package becomes unbuildable without an extra subinclude. This seems like an inadvertent breaking change.
I'm not particularly interested in trying to debug it right now though, I just want to figure out why my build is broken for #157 