### PR TITLE
Abi hdrs from deps

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -375,7 +375,7 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             deps = [transitive_headers],
         )
         lib_rule = go_library(
-            name = f'_{name}#libsss',
+            name = f'_{name}#lib',
             srcs = srcs,
             resources = resources,
             deps = deps,

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -255,6 +255,14 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
     private = out.startswith('_')
     package_path = _get_import_path(package, import_path)
 
+    hdrs_rule = filegroup(
+        name = name,
+        tag = "hdrs",
+        srcs = hdrs,
+        visibility = visibility,
+        test_only = test_only,
+    )
+
     if _module:
         # We're in a module, create a modinfo file identifying it
         modinfo = build_rule(
@@ -339,12 +347,20 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             # a subdirectory for go to be able to transparently import them.
             src_labels += [f'link:plz-out/go/src/$PKG/{libname}']
     if asm_srcs:
+        transitive_headers = filegroup(
+            name = name,
+            tag = "transitive_hdrs",
+            exported_deps = deps,
+            requires = ["hdrs"],
+            needs_transitive_deps = True,
+            test_only = test_only,
+        )
         abi_rule = build_rule(
             name = name,
             tag = 'abi',
             srcs = {
                 'asm': asm_srcs,
-                'hdrs': hdrs,
+                'hdrs': [hdrs_rule],
             },
             outs = [name + '.abi'],
             building_description = 'Creating ABI...',
@@ -356,9 +372,10 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             tools=[CONFIG.GO.GO_TOOL],
             test_only = test_only,
             labels=labels,
+            deps = [transitive_headers],
         )
         lib_rule = go_library(
-            name = f'_{name}#lib',
+            name = f'_{name}#libsss',
             srcs = srcs,
             resources = resources,
             deps = deps,
@@ -369,15 +386,16 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             _needs_transitive_deps = _needs_transitive_deps,
             _all_srcs = _all_srcs,
             _generate_import_config=False,
-            labels=labels,
+            labels=labels + ["foo"],
             import_path=package_path,
         )
+        deps += [lib_rule]
         asm_rule = build_rule(
             name = name,
             tag = 'asm',
             srcs = {
                 'asm': asm_srcs,
-                'hdrs': hdrs,
+                'hdrs': [hdrs_rule],
                 'goasm': [lib_rule + '|h'],
             },
             outs = [name + '.o'],
@@ -390,8 +408,9 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             tools=[CONFIG.GO.GO_TOOL],
             test_only = test_only,
             labels=labels,
+            deps = [transitive_headers],
         )
-        provides = {'go': ':' + name, 'go_src': lib_rule, 'modinfo': modinfo}
+        provides = {'go': ':' + name, 'go_src': lib_rule, 'modinfo': modinfo, 'hdrs': hdrs_rule}
         if cover and not CONFIG.GO.COVERAGEREDESIGN:
             provides['cover_vars'] = cover_vars
         return build_rule(
@@ -456,13 +475,13 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
     if pgo_file:
         srcs['pgo'] = [pgo_file]
 
-    provides = {'go': ':' + name, 'go_src': src_rule, 'modinfo': modinfo}
+    provides = {'go': ':' + name, 'go_src': src_rule, 'modinfo': modinfo, 'hdrs': hdrs_rule}
     if cover and not CONFIG.GO.COVERAGEREDESIGN:
         provides['cover_vars'] = cover_vars
     return build_rule(
         name = name,
         srcs = srcs,
-        deps = deps,
+        deps = deps + [hdrs_rule],
         internal_deps = [src_rule],
         outs = outs,
         cmd = _go_library_cmds(import_path=package_path, complete=complete, all_srcs=_all_srcs, cover=cover, filter_srcs=filter_srcs, abi=_abi, embedcfg=embedcfg, pgo_file=pgo_file),


### PR DESCRIPTION
This allows us to get the .h files of go_libraries we depend on. This is useful for cases such as this:
https://github.com/cloudflare/circl/blob/main/dh/x448/curve_amd64.s

Where we want to include a header from a dep using `../../math/fp448/fp_amd64.h`

We should do this through the normal require/provide setup once we figure out https://github.com/thought-machine/please/pull/2931#pullrequestreview-1694684974