### PR TITLE
Cgo fixes

### DIFF
--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -97,7 +97,7 @@ def cgo_library(name:str, srcs:list=[], resources:list=None, go_srcs:list=[], c_
         srcs = [cgo_rule + '|c'] + c_srcs,
         hdrs = [cgo_rule + '|h'] + hdrs,
         compiler_flags = compiler_flags + [
-            '-Wno-error',
+            '-I', '"$PKG_DIR"',
             '-Wno-unused-parameter',  # Generated code doesn't compile clean
         ],
         pkg_config_libs = pkg_config,

--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -2,7 +2,7 @@ subinclude("///go//build_defs:go", "///cc//build_defs:c")
 
 def cgo_library(name:str, srcs:list=[], resources:list=None, go_srcs:list=[], c_srcs:list=[], hdrs:list=[],
                 package:str=None, compiler_flags:list&cflags=[], linker_flags:list&ldflags=[], pkg_config:list=[],
-                subdir:str='', deps:list=[], visibility:list=None, test_only:bool&testonly=False, import_path:str=''):
+                subdir:str='', deps:list=[], visibility:list=None, test_only:bool&testonly=False, _module:str='', import_path:str=''):
     """Generates a Go library which can be reused by other rules.
 
     Note that by its nature this is something of a hybrid of Go and C rules. It can depend


### PR DESCRIPTION
Hello this is two simple fix that make go_rules work better in cgo mode

# Add _module parameter generated by please_go

see https://github.com/please-build/go-rules/pull/164#issuecomment-1780838014

- Remove -Wno-error, include PKG_DIR

Fix #149 

cc_library include . (-I .) but cgo put all files in PKG_DIR