### PR TITLE
Optionally validate `version` parameter in `go_mod_download`

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -37,6 +37,11 @@ Type = bool
 Inherit = true
 Help = If set, the licences field on go_module and go_repo will be mandatory
 
+[PluginConfig "validate_module_version"]
+DefaultValue = false
+Type = bool
+Help = If set, the values of go_mod_download's module and version parameters will be validated.
+
 [PluginConfig "import_path"]
 Help = The base import path when compiling first party Go code. This usually is set to the module name in go.mod.
 Optional = true

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1262,11 +1262,15 @@ def go_mod_download(name:str, module:str, version:str, test_only:bool=False, vis
         label = canonicalise(f":{name}")
         fail(f"{label} is missing its licence")
 
+    validate = " --validate" if CONFIG.GO.VALIDATE_MODULE_VERSION else ""
     modinfo = build_rule(
         name = name,
-        tag = "modinfo",
+        tag = "mod_version",
         outs = [f"_{name}.modinfo"],
-        cmd = f"echo '{module}@{version}' > $OUT",
+        cmd = f"$TOOLS_PLZGO generate_module_version{validate} -m {module} --version {version}",
+        tools = {
+            "plzgo": CONFIG.GO.PLEASE_GO_TOOL,
+        },
         requires = ["modinfo"],
         test_only = test_only,
         deps = deps,

--- a/tools/please_go/modinfo/BUILD
+++ b/tools/please_go/modinfo/BUILD
@@ -9,6 +9,9 @@ filegroup(
 go_library(
     name = "modinfo",
     srcs = ["modinfo.go"],
+    deps = [
+        "//third_party/go:mod",
+    ],
     visibility = [
         "//tools/please_go/...",
     ],

--- a/tools/please_go/modinfo/modinfo.go
+++ b/tools/please_go/modinfo/modinfo.go
@@ -12,6 +12,8 @@ import (
 	"runtime/debug"
 	"sort"
 	"strings"
+
+	"golang.org/x/mod/module"
 )
 
 // WriteModInfo writes mod info to the given output file
@@ -72,4 +74,18 @@ func modInfoData(modinfo string) string {
 	start, _ := hex.DecodeString("3077af0c9274080241e1c107e6d618e6")
 	end, _ := hex.DecodeString("f932433186182072008242104116d8f2")
 	return string(start) + modinfo + string(end)
+}
+
+// WriteModuleVersion generates a module version file for a third-party Go module.
+//
+// If validate is true, WriteModuleVersion additionally checks that the given module path and version are valid
+// according to Go's module version numbering standard.
+func WriteModuleVersion(modulePath, version string, validate bool, outputFile string) error {
+	if validate {
+		if err := module.Check(modulePath, version); err != nil {
+			return fmt.Errorf("invalid module path/version: %v", err)
+		}
+	}
+	canonicalVersion := module.CanonicalVersion(version)
+	return os.WriteFile(outputFile, []byte(fmt.Sprintf("%s@%s", modulePath, canonicalVersion)), 0644)
 }

--- a/tools/please_go/modinfo/modinfo_test.go
+++ b/tools/please_go/modinfo/modinfo_test.go
@@ -29,6 +29,14 @@ func TestModInfo(t *testing.T) {
 			Version: "v1.7.0",
 		},
 		{
+			Path:    "golang.org/x/mod",
+			Version: "v0.5.0",
+		},
+		{
+			Path:    "golang.org/x/xerrors",
+			Version: "v0.0.0-20200804184101-5ec99f83aff1",
+		},
+		{
 			Path:    "gopkg.in/yaml.v3",
 			Version: "v3.0.0-20210107192922-496545a6307b",
 		},

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -120,6 +120,12 @@ var opts = struct {
 		GoOS       string `long:"goos" env:"OS" description:"OS we're compiling for"`
 		GoArch     string `long:"goarch" env:"ARCH" description:"Architecture we're compiling for"`
 	} `command:"modinfo" description:"Generates Go modinfo for the linter"`
+	GenerateModuleVersion struct {
+		ModulePath string `short:"m" long:"module_path" required:"true" description:"The module's path"`
+		Version    string `long:"version" required:"true" description:"The module's (semantic) version number"`
+		Validate   bool   `long:"validate" description:"Check validity of the given module import path and version number"`
+		Out        string `short:"o" long:"out" env:"OUT" required:"true" description:"File to write the output to"`
+	} `command:"generate_module_version" description:"Generates a module version file for a third-party Go module"`
 }{
 	Usage: `
 please-go is used by the go build rules to compile and test go modules and packages.
@@ -217,6 +223,13 @@ var subCommands = map[string]func() int{
 		}
 		if err := modinfo.WriteModInfo(mi.GoTool, mi.ModulePath, filepath.Join(mi.ModulePath, mi.Pkg), mi.BuildMode, mi.CgoEnabled, mi.GoOS, mi.GoArch, mi.Out); err != nil {
 			log.Fatalf("failed to write modinfo: %s", err)
+		}
+		return 0
+	},
+	"generate_module_version": func() int {
+		mv := opts.GenerateModuleVersion
+		if err := modinfo.WriteModuleVersion(mv.ModulePath, mv.Version, mv.Validate, mv.Out); err != nil {
+			log.Fatalf("failed to generate module version file: %v", err)
 		}
 		return 0
 	},


### PR DESCRIPTION
This introduces a new plugin option, `validate_module_version`, that performs sanity checks on the module name and version strings for third-party Go modules downloaded with `go_mod_download`. When enabled, only version strings that conform to Go's module version numbering policy are permitted.

So, with `validate_module_version = true` in `.plzconfig`:

```
$ cat t/BUILD
subinclude("//build_defs:go")

go_module(
    name = "go-pluralize",
    install = ["..."],
    licences = ["MIT"],
    module = "github.com/gertd/go-pluralize",
    version = "v0.2.0",
)

$ plz build //t:go-pluralize
Build finished; total time 4.11s, incrementality 95.8%. Outputs:
//t:go-pluralize:
  plz-out/gen/t/pkg/linux_amd64/github.com/gertd/go-pluralize
```

but:

```
$ cat t/BUILD
subinclude("//build_defs:go")

go_module(
    name = "go-pluralize",
    install = ["..."],
    licences = ["MIT"],
    module = "github.com/gertd/go-pluralize",
    version = "8c94b92eb8ba076775a4c86b8d835783b4d391c4",
)

$ plz build //t:go-pluralize
Build stopped after 3.82s. 1 target failed:
    //t:_go-pluralize#mod_version
[...]
Stderr:
2023/10/30 11:39:50 failed to generate module version file: invalid module path/version: github.com/gertd/go-pluralize@8c94b92eb8ba076775a4c86b8d835783b4d391c4: invalid version: not a semantic version
```

`validate_module_version` is disabled by default because enabling it would be a breaking change - perhaps we can enable it by default for go-rules v2.

Fixes #153.