### PR TITLE
Refactor the pkginfo code and fix issue with go_libraries in subrepos

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1502,7 +1502,11 @@ def _go_modinfo(name:str, test_only:bool=False, deps:list):
 
 def _go_pkg_info(name:str, srcs:list, importconfig:str=None, import_path:str="", package:str="", test_only:bool=False):
     """Internal-only function for generating the pkg_info files for a single package"""
-
+    # There's inconsistency between the import path passed to `go tool compile` vs. the package response you get from
+    # `go list`. The internal tools ignore modules etc. for the main package, passing `-p main` even though the package
+    # driver response returns the normal package ID. This is a simple fix.
+    if import_path == "main":
+        import_path = ""
     import_path = _get_import_path(package, import_path)
     cmd = f'$TOOL package_info -i "{import_path}" -e "$PKG_DIR/{package}.a" > $OUT'
     return build_rule(

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -172,7 +172,7 @@ def go_stdlib(name:str, tags:list=[], visibility:list=["PUBLIC"]):
         "rm -rf pkg/tool pkg/include",
         "mv pkg $OUTS_PKG",
         f'find "$OUTS_PKG" -name "*.a" | sed -e "s=^$OUTS_PKG/{CONFIG.OS}_{CONFIG.ARCH}{suffix}/==" | sed -e s="\.a$"== | xargs -I{{}} echo "packagefile {{}}="$PKG_DIR/$OUTS_PKG"/{CONFIG.OS}_{CONFIG.ARCH}{suffix}/{{}}.a" | sort -u > $OUTS_IC',
-        '$TOOLS_PLZGO m -m "" -s "$SRCS" --importconfig "$OUTS_IC" > $OUTS_PKG_INFO',
+        '$TOOLS_PLZGO m -m "" --src_root "$SRCS" --importconfig "$OUTS_IC" > $OUTS_PKG_INFO',
     ]
     return genrule(
         name = name,
@@ -451,7 +451,6 @@ def go_library(name:str, srcs:list, resources:list=[], asm_srcs:list=None, hdrs:
             srcs = srcs + resources,
             import_path = import_path,
             package = package,
-            complete = complete,
             test_only = test_only,
         )]
 
@@ -1455,11 +1454,10 @@ def go_module(name:str='', module:str, version:str='', download:str='', deps:lis
 
     # Package info rule for the Go packages driver
     if CONFIG.GO.PKG_INFO:
-        pkg_info = _go_pkg_info(
+        pkg_info = _go_module_info(
             name = name,
-            srcs = [download],
+            download = download,
             importconfig = import_config,
-            strip = True,
             module = module,
             test_only = test_only,
             install = installpkg,
@@ -1502,20 +1500,11 @@ def _go_modinfo(name:str, test_only:bool=False, deps:list):
     )
 
 
-def _go_pkg_info(name:str, srcs:list, importconfig:str=None, import_path:str="", package:str="",
-                 strip:bool=False, module:str="", complete:bool=False, test_only:bool=False, install:list=[]):
-    """Internal-only function for generating the pkg_info files"""
-    sflag = '-s "$SRCS_SRCS"' if strip else ''
+def _go_pkg_info(name:str, srcs:list, importconfig:str=None, import_path:str="", package:str="", test_only:bool=False):
+    """Internal-only function for generating the pkg_info files for a single package"""
 
-    install_flags = ""
-    for i in install:
-        install_flags += f" -p {i}" if i else " -p ."
-
-    if module:
-        cmd = f'$TOOL m -m {module} {install_flags}'
-    else:
-        import_path = _get_import_path(package, import_path)
-        cmd = f'$TOOL p -i "{CONFIG.GO.IMPORT_PATH}" -m "{import_path}:$PKG_DIR/{package}.a"'
+    import_path = _get_import_path(package, import_path)
+    cmd = f'$TOOL package_info -i "{import_path}" -e "$PKG_DIR/{package}.a" > $OUT'
     return build_rule(
         name = name,
         tag = "pkg_info",
@@ -1525,7 +1514,30 @@ def _go_pkg_info(name:str, srcs:list, importconfig:str=None, import_path:str="",
             "ic": [importconfig],
         },
         outs = [f"_{name}_pkg_info.json"],
-        cmd = f'{cmd} {sflag} > "$OUTS"',
+        cmd = cmd,
+        labels = ["go_pkg_info"],
+        test_only = test_only,
+    )
+
+def _go_module_info(name:str, download:str, importconfig:str=None, module:str="", test_only:bool=False, install:list=[]):
+    """Internal-only function for generating the pkg_info files for a module"""
+
+    install_flags = ""
+    for i in install:
+        install_flags += f" -p {i}" if i else " -p ."
+
+    cmd = f'$TOOL module_info --module={module} --src_root=$(location {download}) {install_flags} > $OUT'
+
+    return build_rule(
+        name = name,
+        tag = "pkg_info",
+        tools = [CONFIG.GO.PLEASE_GO_TOOL],
+        srcs = {
+            "srcs": [download],
+            "ic": [importconfig],
+        },
+        outs = [f"_{name}_pkg_info.json"],
+        cmd = cmd,
         labels = ["go_pkg_info"],
         test_only = test_only,
     )

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1506,8 +1506,10 @@ def _go_pkg_info(name:str, srcs:list, importconfig:str=None, import_path:str="",
     # `go list`. The internal tools ignore modules etc. for the main package, passing `-p main` even though the package
     # driver response returns the normal package ID. This is a simple fix.
     if import_path == "main":
-        import_path = ""
-    import_path = _get_import_path(package, import_path)
+        import_path = _get_import_path("", "")
+    else:
+        import_path = _get_import_path(package, import_path)
+
     cmd = f'$TOOL package_info -i "{import_path}" -e "$PKG_DIR/{package}.a" > $OUT'
     return build_rule(
         name = name,

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -16,58 +16,64 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// WritePackageInfo writes a series of package info files to the given file.
-func WritePackageInfo(modulePath, strip, src, importconfig string, imports map[string]string, installPkgs []string, w io.Writer) error {
-	// Discover all Go files in the module
-	goFiles := map[string][]string{}
+// WriteModuleInfo writes a series of package info files to the given file.
+func WriteModuleInfo(srcRoot, module, importConfigPath string, pkgWildcards []string, w io.Writer) error {
+	importConfig, err := loadImportConfig(importConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to read importConfigPath: %w", err)
+	}
 
+	var pkgs []*packages.Package
 	walkDirFunc := func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() {
+			return nil
+		}
 		if err != nil {
 			return err
-		} else if name := d.Name(); name == "testdata" {
-			return filepath.SkipDir // Don't descend into testdata
-		} else if strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") {
-			dir := filepath.Dir(path)
-			goFiles[dir] = append(goFiles[dir], path)
 		}
+		if name := d.Name(); name == "testdata" {
+			return filepath.SkipDir // Don't descend into testdata
+		}
+
+		path, err = filepath.Rel(srcRoot, path)
+		if err != nil {
+			return err
+		}
+
+		pkgID := filepath.Join(module, path)
+		pkg, err := createPackage(pkgID, filepath.Join(srcRoot, path), importConfig[pkgID])
+		if err != nil {
+			// Ignore this for wildcards.
+			if _, ok := err.(*build.NoGoError); ok {
+				return nil
+			}
+			return err
+		}
+		pkgs = append(pkgs, pkg)
 		return nil
 	}
-	// Check install packages first
-	for _, pkg := range installPkgs {
+
+	// Default to the whole module
+	if len(pkgWildcards) == 0 {
+		pkgWildcards = []string{"..."}
+	}
+
+	for _, pkg := range pkgWildcards {
 		if strings.Contains(pkg, "...") {
 			pkg = strings.TrimSuffix(pkg, "...")
-			if err := filepath.WalkDir(filepath.Join(src, pkg), walkDirFunc); err != nil {
+			if err := filepath.WalkDir(filepath.Join(srcRoot, pkg), walkDirFunc); err != nil {
 				return fmt.Errorf("failed to read module dir: %w", err)
 			}
 		} else {
-			dir := filepath.Join(src, pkg)
-			goFiles[dir] = append(goFiles[dir], filepath.Join(src, pkg))
+			pkgID := filepath.Join(module, pkg)
+			pkg, err := createPackage(pkgID, filepath.Join(srcRoot, pkg), importConfig[pkgID])
+			if err != nil {
+				return err
+			}
+			pkgs = append(pkgs, pkg)
 		}
 	}
-	if len(installPkgs) == 0 {
-		if err := filepath.WalkDir(src, walkDirFunc); err != nil {
-			return fmt.Errorf("failed to read module dir: %w", err)
-		}
-	}
-	if importconfig != "" {
-		m, err := loadImportConfig(importconfig)
-		if err != nil {
-			return fmt.Errorf("failed to read importconfig: %w", err)
-		}
-		imports = m
-	}
-	pkgs := make([]*packages.Package, 0, len(goFiles))
-	for dir := range goFiles {
-		pkgDir := strings.TrimPrefix(strings.TrimPrefix(dir, strip), "/")
-		pkg, err := createPackage(filepath.Join(modulePath, pkgDir), dir)
-		if _, ok := err.(*build.NoGoError); ok {
-			continue // Don't really care, this happens sometimes for modules
-		} else if err != nil {
-			return fmt.Errorf("failed to import directory %s: %w", dir, err)
-		}
-		pkg.ExportFile = imports[pkg.PkgPath]
-		pkgs = append(pkgs, pkg)
-	}
+
 	// Ensure output is deterministic
 	sort.Slice(pkgs, func(i, j int) bool {
 		return pkgs[i].ID < pkgs[j].ID
@@ -75,21 +81,25 @@ func WritePackageInfo(modulePath, strip, src, importconfig string, imports map[s
 	return serialise(pkgs, w)
 }
 
-func createPackage(pkgPath, pkgDir string) (*packages.Package, error) {
-	if pkgDir == "" || pkgDir == "." {
-		// This happens when we're in the repo root, ImportDir refuses to read it for some reason.
-		path, err := filepath.Abs(pkgDir)
-		if err != nil {
-			return nil, err
-		}
-		pkgDir = path
+// WritePackageInfo writes info for a single package
+func WritePackageInfo(pkgDir, importPath string, exportFile string, w io.Writer) error {
+	pkg, err := createPackage(importPath, pkgDir, exportFile)
+	if err != nil {
+		return err
 	}
-	bpkg, err := build.ImportDir(pkgDir, build.ImportComment)
+
+	return serialise([]*packages.Package{pkg}, w)
+}
+
+func createPackage(importPath, pkgDir, exportFile string) (*packages.Package, error) {
+	buildPkg, err := build.ImportDir(pkgDir, build.ImportComment)
 	if err != nil {
 		return nil, err
 	}
-	bpkg.ImportPath = pkgPath
-	return FromBuildPackage(bpkg), nil
+	buildPkg.ImportPath = importPath
+	pkg := FromBuildPackage(buildPkg)
+	pkg.ExportFile = exportFile
+	return pkg, nil
 }
 
 func serialise(pkgs []*packages.Package, w io.Writer) error {

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -80,14 +80,13 @@ var opts = struct {
 		} `positional-args:"true"`
 	} `command:"embed" alias:"f" description:"Filter go sources based on the go build tag rules."`
 	PackageInfo struct {
-		ImportPath string            `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
-		Pkg        string            `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
-		ImportMap  map[string]string `short:"m" long:"import_map" description:"Existing map of imports"`
+		ImportPath string `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
+		Pkg        string `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
+		ExportFile string `short:"e" long:"export_file" description:"The export file for this package"`
 	} `command:"package_info" alias:"p" description:"Creates an info file about a Go package"`
 	ModuleInfo struct {
-		ModulePath   string   `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
-		Strip        string   `short:"s" long:"strip" description:"Prefix to strip off package directories"`
-		Srcs         string   `long:"srcs" env:"SRCS_SRCS" required:"true" description:"Source files of the module"`
+		ModulePath   string   `short:"m" long:"module" required:"true" description:"The module name"`
+		SrcRoot      string   `long:"src_root" required:"true" description:"Source root of the module"`
 		ImportConfig string   `long:"importconfig" env:"SRCS_IC" description:"Importconfig file for locating gc export data"`
 		Packages     []string `short:"p" long:"packages" description:"Packages to include in the module"`
 	} `command:"module_info" alias:"m" description:"Creates an info file about a series of packages in a go_module"`
@@ -194,14 +193,14 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, "", pi.Pkg, "", pi.ImportMap, nil, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.Pkg, pi.ImportPath, pi.ExportFile, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Strip, mi.Srcs, mi.ImportConfig, nil, mi.Packages, os.Stdout); err != nil {
+		if err := packageinfo.WriteModuleInfo(mi.SrcRoot, mi.ModulePath, mi.ImportConfig, mi.Packages, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0


### PR DESCRIPTION
There was an issue in subrepos created via `go_repo` where we'd include the pkgpath in $PKGDIR. The assumption that `importPath := filepath.Join(module, pkgDir)` where `pkgDir` is `$PKG_DIR`, doesn't hold for this case. We'd end up with `github.com/owner/module/pkg/src/github.com/owner/pkg/src` as the import path. 

This PR refactors the code so we have different entry points for `go_library` and `go_module` that are more explicit about these arguments. I have done some spot checking, comparing the results from `//third_party/go:std`, `//tools/please_go/packageinfo` and `///third_party/go/github.com_stretchr_testify//assert` and they all look good. One small thing is we're now returning empty packages for directories that contain only test sources:

```
  {
    "ID": "cmd/api",
    "Name": "main",
    "PkgPath": "cmd/api"
  },
```

This is probably harmless but I think the package driver should include test sources somehow. The fact that it doesn't in probably a bug. 