### PR TITLE
go_repo: Generate subrepo with the same package root as when building a target in the subrepo

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1228,7 +1228,7 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
         name = name,
         tag = "repo" if install else None,
         srcs =  srcs,
-        cmd  = f"rm -rf $SRCS_DOWNLOAD/.plzconfig && find $SRCS_DOWNLOAD -name BUILD -delete && mkdir -p pkgRoot && mv $SRC_DOWNLOAD {pkgRoot} && $TOOL generate {modFileArg} --module {module} --version '{version}' {build_tag_args} --src_root={pkgRoot} --third_part_folder='{third_party_path}' {install_args} {requirements} && mv {pkgRoot} $OUT",
+        cmd  = f"rm -rf $SRCS_DOWNLOAD/.plzconfig && find $SRCS_DOWNLOAD -name BUILD -delete && mkdir -p $(dirname {pkgRoot}) && mv $SRCS_DOWNLOAD {pkgRoot} && $TOOL generate {modFileArg} --module {module} --version '{version}' {build_tag_args} --src_root={pkgRoot} --third_part_folder='{third_party_path}' {install_args} {requirements} && mv {pkgRoot} $OUT",
         outs = [subrepo_name],
         tools = [CONFIG.GO.PLEASE_GO_TOOL],
         env= {

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1222,11 +1222,13 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
 
     build_tag_args = '--build_tag ' + ' --build_tag '.join(build_tags) if build_tags else ''
 
+    pkgRoot = f"pkg/{CONFIG.OS}_{CONFIG.ARCH}/{module}"
+
     repo = build_rule(
         name = name,
         tag = "repo" if install else None,
         srcs =  srcs,
-        cmd  = f"rm -rf $SRCS_DOWNLOAD/.plzconfig && find $SRCS_DOWNLOAD -name BUILD -delete && $TOOL generate {modFileArg} --module {module} --version '{version}' {build_tag_args} --src_root=$SRCS_DOWNLOAD --third_part_folder='{third_party_path}' {install_args} {requirements} && mv $SRCS_DOWNLOAD $OUT",
+        cmd  = f"rm -rf $SRCS_DOWNLOAD/.plzconfig && find $SRCS_DOWNLOAD -name BUILD -delete && mkdir -p pkgRoot && mv $SRC_DOWNLOAD {pkgRoot} && $TOOL generate {modFileArg} --module {module} --version '{version}' {build_tag_args} --src_root={pkgRoot} --third_part_folder='{third_party_path}' {install_args} {requirements} && mv {pkgRoot} $OUT",
         outs = [subrepo_name],
         tools = [CONFIG.GO.PLEASE_GO_TOOL],
         env= {
@@ -1242,7 +1244,7 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
     subrepo(
         name = subrepo_name,
         dep = repo,
-        package_root = f"pkg/{CONFIG.OS}_{CONFIG.ARCH}/{module}",
+        package_root = pkgRoot,
     )
 
     if install:


### PR DESCRIPTION
Before we would resolve `-I.` to the directory where we generated the subrepo which would be different to the location when actually compiling the go_library because the subrepo has a package root set. This makes sure that the paths are the same at generate and build time. 