### PR TITLE
Enforce ordering of ldflags

### DIFF
--- a/tools/please_go/generate/generate.go
+++ b/tools/please_go/generate/generate.go
@@ -452,7 +452,7 @@ func (g *Generate) ruleForPackage(pkg *build.Package, dir string) *Rule {
 		cgoSrcs:       pkg.CgoFiles,
 		cSrcs:         pkg.CFiles,
 		compilerFlags: pkg.CgoCFLAGS,
-		linkerFlags:   pkg.CgoLDFLAGS,
+		linkerFlags:   orderLinkerFlags(pkg.CgoLDFLAGS),
 		pkgConfigs:    pkg.CgoPkgConfig,
 		asmFiles:      pkg.SFiles,
 		hdrs:          pkg.HFiles,
@@ -460,6 +460,14 @@ func (g *Generate) ruleForPackage(pkg *build.Package, dir string) *Rule {
 		embedPatterns: pkg.EmbedPatterns,
 		isCMD:         pkg.IsCommand(),
 	}
+}
+
+// orderLinkerFlags collapses linker flags into one to enforce a consistent ordering
+func orderLinkerFlags(in []string) []string {
+	if len(in) > 0 {
+		return []string{strings.Join(in, " ")}
+	}
+	return nil
 }
 
 func (g *Generate) depTarget(importPath string) string {


### PR DESCRIPTION
This is a nasty little one. We can get ldflags where order is important - e.g. `{"path/to/something.a", "-lm"}` where `something.a` needs libm; they have to be passed in that order. This ordering gets lost in their path to the final binary though; by that point they're alphabetised.

This isn't the nicest solution ever but it ensures the order remains the same.