### PR TITLE
Filter stdlib from package_info.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/please-build/go-rules
 
-go 1.18
+go 1.20
 
 require github.com/stretchr/testify v1.7.1
 

--- a/tools/please_go/go.mod
+++ b/tools/please_go/go.mod
@@ -1,6 +1,6 @@
 module github.com/please-build/go-rules/tools/please_go
 
-go 1.17
+go 1.20
 
 require (
 	github.com/bazelbuild/buildtools v0.0.0-20221110131218-762712d8ce3f

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 
@@ -79,6 +80,13 @@ func WritePackageInfo(importPath string, srcRoot, importconfig string, imports m
 			pkg.ExportFile = imports[pkg.PkgPath]
 		}
 		pkgs = append(pkgs, pkg)
+	}
+	// If we're doing the stdlib, limit it to just things in the importconfig (i.e. no cmd/ packages)
+	if importconfig != "" {
+		pkgs = slices.DeleteFunc(pkgs, func(pkg *packages.Package) bool {
+			_, present := imports[pkg.PkgPath]
+			return !present
+		})
 	}
 	// Ensure output is deterministic
 	sort.Slice(pkgs, func(i, j int) bool {


### PR DESCRIPTION
This just cuts a bunch of noise out of the package driver output; we don't need to output all the `cmd/` packages (these can't actually be imported anyway because they're not in the importconfig file)