### PR TITLE
Add noremote option to plzconfig

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -170,3 +170,6 @@ Help = Build tags to pass to the Go compiler
 
 [Plugin "shell"]
 Target = //plugins:shell
+
+[remote]
+url =


### PR DESCRIPTION
To ensure any configured remotes are bypassed and this repository is built locally in all instances.