### PR TITLE
Generate skip hidden dirs

### DIFF
--- a/test/go_repo/test_repo/third_party/go/BUILD_FILE
+++ b/test/go_repo/test_repo/third_party/go/BUILD_FILE
@@ -38,3 +38,11 @@ go_module(
     licences = ["MIT"],
     visibility = ["PUBLIC"],
 )
+
+go_repo(
+    name = "okta-sdk-golang",
+    install = ["..."],
+    licences = ["Apache-2.0"],
+    module = "github.com/okta/okta-sdk-golang/v2",
+    version = "v2.16.0",
+)

--- a/tools/please_go/generate/generate.go
+++ b/tools/please_go/generate/generate.go
@@ -69,7 +69,7 @@ func (g *Generate) Generate() error {
 	g.moduleDeps = append(g.moduleDeps, g.moduleName)
 	g.replace = replacements
 
-	if err := g.writeConfig(); err != nil {
+	if err := g.writePleaseConfig(); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 	if err := g.parseImportConfigs(); err != nil {
@@ -202,7 +202,7 @@ func (g *Generate) writeInstallFilegroup() error {
 	return saveBuildFile(buildFile)
 }
 
-func (g *Generate) writeConfig() error {
+func (g *Generate) writePleaseConfig() error {
 	file, err := os.Create(filepath.Join(g.srcRoot, ".plzconfig"))
 	if err != nil {
 		return err


### PR DESCRIPTION
We're running into an issue with hidden directories being detected as buildable go modules which fail to build.  This adds an example to the test repository and includes the fix in a subsequent commit.