### PR TITLE
Add `strip_binaries` configuration option

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -17,7 +17,7 @@ Target = //plugins:cc
 
 [Plugin "e2e"]
 Target = //plugins:e2e
-PleaseVersion = 16.26.1
+PleaseVersion = 17.10.0
 
 [PluginDefinition]
 Name = go

--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-Version = >=17.2.0
+Version = >=17.10.0
 
 [build]
 hashcheckers = sha256
@@ -133,6 +133,12 @@ Help = Split debug info for binaries into a separate, optional output.
 DefaultValue = eu-strip
 Inherit = true
 Help = Tool to use to strip debug info. This is temporary and will be removed later!
+
+[PluginConfig "strip_binaries"]
+Optional = true
+Inherit = true
+Type = bool
+Help = Whether to strip generated Go binaries by default. This overrides the behaviour implied by the build mode - for example, building in dbg mode with this option set to true will still cause Go binaries to be stripped.
 
 [PluginConfig "feature_flags"]
 Repeatable = true

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -587,7 +587,7 @@ def _get_import_path(package="", import_path=""):
 
 def go_binary(name:str, srcs:list=[], resources:list=None, asm_srcs:list=[], out:str=None, deps:list=[], data:list|dict=None,
               visibility:list=None, labels:list=[], test_only:bool&testonly=False, static:bool=CONFIG.GO.DEFAULT_STATIC,
-              filter_srcs:bool=True, definitions:str|list|dict=None, stamp:bool=False, strip:bool=None):
+              filter_srcs:bool=True, definitions:str|list|dict=None, stamp:bool=False, strip:bool=CONFIG.GO.STRIP_BINARIES):
     """Compiles a Go binary.
 
     Args:
@@ -614,8 +614,10 @@ def go_binary(name:str, srcs:list=[], resources:list=None, asm_srcs:list=[], out
                      used to contruct the list of definitions passed to the linker.
       stamp (bool): Allows this rule to gain access to information about SCM revision etc
                     via env vars. These can be useful to pass into `definitions`.
-      strip (bool): Determines whether the binary will be stripped of debug symbols or not.
-                    By default it depends on the build mode.
+      strip (bool): Determines whether the binary will be stripped of debug symbols or not. By
+                    default the value of the strip_binaries plugin configuration option is used;
+                    if this is not set, whether or not the binary is stripped depends on the
+                    build mode.
     """
     _srcs = srcs or [name + '.go']
     lib = go_library(


### PR DESCRIPTION
Whether or not generated Go binaries are stripped is determined by the build mode: `opt` strips them, `dbg` doesn't. There are cases in which we might want to avoid stripping binaries even when building them in `opt` mode - a notable example is to preserve the `.symtab` table, which [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) uses to perform a deeper analysis of whether vulnerable code is called by the binary.

Add an option to the plugin configuration, `strip_binaries`, that causes binaries to be stripped or not stripped regardless of the build mode. If a value is not set for `strip_binaries`, `go_binary` behaves as it does currently (i.e. stripping behaviour depends on the build mode).