### PR TITLE
Bump minimum Please version to v17.10.1

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-Version = >=17.10.0
+Version = >=17.10.1
 
 [build]
 hashcheckers = sha256
@@ -17,7 +17,7 @@ Target = //plugins:cc
 
 [Plugin "e2e"]
 Target = //plugins:e2e
-PleaseVersion = 17.10.0
+PleaseVersion = 17.10.1
 
 [PluginDefinition]
 Name = go


### PR DESCRIPTION
This should fix a bug that is blocking the go-rules release workflow (see https://github.com/thought-machine/please/pull/3223).