### PR TITLE
Bump plugin-integration-testing plugin to v1.0.3

### DIFF
--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "e2e",
     plugin = "plugin-integration-testing",
-    revision="v1.0.2"
+    revision = "v1.0.3",
 )
 
 plugin_repo(


### PR DESCRIPTION
This fixes e2e test failures in environments where remote execution is enabled by default via a config file in `/etc/please/`.