### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: logs
-          path: |
-            plz-out/log
+          path: plz-out/log
   test_coverage:
     runs-on: ubuntu-latest
     steps:
@@ -27,8 +26,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_logs
-          path: |
-            plz-out/log
+          path: plz-out/log
   test_tools:
     runs-on: ubuntu-latest
     steps:
@@ -41,8 +39,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tools_logs
-          path: |
-            plz-out/log
+          path: plz-out/log
   test_debug:
     runs-on: ubuntu-latest
     steps:
@@ -55,8 +52,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: debug_logs
-          path: |
-            plz-out/log
+          path: plz-out/log
   release:
     needs:
       - test

--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -10,7 +10,7 @@ jobs:
         run: ./pleasew test -p -v notice --log_file plz-out/log/test.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
           path: |
@@ -24,7 +24,7 @@ jobs:
         run: ./pleasew cover -p -v notice --nocoverage_report --log_file plz-out/log/test_coverage.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage_logs
           path: |
@@ -38,7 +38,7 @@ jobs:
         run: ./pleasew cover -p -v notice --nocoverage_report --log_file plz-out/log/test_tools.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tools_logs
           path: |
@@ -52,7 +52,7 @@ jobs:
         run: ./pleasew build -c dbg -p -v notice --log_file plz-out/log/test_debug.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: debug_logs
           path: |


### PR DESCRIPTION
Apparently upload-artifact/v2 was deprecated and is now removed. I guess if I increase this number then maybe builds will succeed again.