### PR TITLE
Cgo asm srcs

### DIFF
--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -17,6 +17,7 @@ def cgo_library(
     visibility:list=None,
     test_only:bool&testonly=False,
     import_path:str='',
+    asm_srcs:list=None,
     _module:str='',
     _subrepo:str='',
 ):
@@ -69,6 +70,7 @@ def cgo_library(
             import_path = import_path,
             visibility = visibility,
             test_only = test_only,
+            asm_srcs = asm_srcs,
             _module = _module,
             _subrepo = _subrepo,
         )
@@ -136,6 +138,7 @@ def cgo_library(
         _subrepo = _subrepo,
         _module = _module,
         labels = labels,
+        asm_srcs = asm_srcs,
     )
 
     output = package if package else name

--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -71,6 +71,7 @@ def cgo_library(
             visibility = visibility,
             test_only = test_only,
             asm_srcs = asm_srcs,
+            hdrs = hdrs,
             _module = _module,
             _subrepo = _subrepo,
         )
@@ -133,6 +134,7 @@ def cgo_library(
         test_only = test_only,
         complete = False,
         deps = deps,
+        hdrs = hdrs,
         _generate_import_config=False,
         import_path=import_path,
         _subrepo = _subrepo,


### PR DESCRIPTION
This was missing from the CGO library, but is valid. The go_repo rules would generate cgo calls like this which came up for DataDog/zstd