### PR TITLE
Migrate the package driver to use the now-exported types for the request/response

### DIFF
--- a/third_party/binary/BUILD
+++ b/third_party/binary/BUILD
@@ -1,8 +1,8 @@
 remote_file(
     name = "gosec_download",
-    hashes = ["226bd8825b7aed3d454446d1ec094f817f37859dded4211a5b707d0f36c5fdb7"],
+    hashes = ["38e596e1ad580666e5efaa159fbaf63bd5873ea1e74beacbdf785b025b52e1db"],
     test_only = True,
-    url = ["https://github.com/securego/gosec/releases/download/v2.14.0/gosec_2.14.0_linux_amd64.tar.gz"],
+    url = ["https://github.com/securego/gosec/releases/download/v2.22.0/gosec_2.22.0_linux_amd64.tar.gz"],
 )
 
 genrule(
@@ -10,7 +10,7 @@ genrule(
     srcs = [":gosec_download"],
     outs = ["gosec"],
     binary = True,
-    cmd = "$TOOLS x $SRCS -s v2.14.0",
+    cmd = "$TOOLS x $SRCS -s v2.22.0",
     test_only = True,
     tools = [CONFIG.ARCAT_TOOL],
     visibility = ["//tools/driver/..."],

--- a/tools/driver/main.go
+++ b/tools/driver/main.go
@@ -16,7 +16,7 @@ var log = logging.MustGetLogger()
 var opts = struct {
 	Usage      string
 	Verbosity  logging.Verbosity `short:"v" long:"verbosity" env:"PLZ_GOPACKAGESDRIVER_VERBOSITY" default:"warning" description:"Verbosity of output (higher number = more output)"`
-	LogFile    string `long:"log_file" env:"PLZ_GOPACKAGESDRIVER_LOG_FILE" description:"Log additionally to this file"`
+	LogFile    string            `long:"log_file" env:"PLZ_GOPACKAGESDRIVER_LOG_FILE" description:"Log additionally to this file"`
 	NoInput    bool              `short:"n" long:"no_input" description:"Assume a default config and don't try to read from stdin"`
 	WorkingDir string            `short:"w" long:"working_dir" description:"Change to this working directory before running"`
 	OutputFile string            `short:"o" long:"output_file" env:"PLZ_GOPACKAGESDRIVER_OUTPUT_FILE" description:"File to write output to (in addition to stdout)"`
@@ -48,7 +48,7 @@ func main() {
 		}
 	}
 
-	req := &packages.DriverRequest{}
+	req := &xpackages.DriverRequest{}
 	if opts.NoInput {
 		req.Mode = xpackages.NeedExportFile
 	} else {
@@ -77,7 +77,7 @@ func main() {
 	}
 }
 
-func load(req *packages.DriverRequest) (*packages.DriverResponse, error) {
+func load(req *xpackages.DriverRequest) (*xpackages.DriverResponse, error) {
 	if opts.SearchDir == "" {
 		return packages.Load(req, opts.Args.Files)
 	}

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -161,7 +160,7 @@ func packagesToResponse(rootpath string, pkgs []*packages.Package, dirs map[stri
 		}
 		pkgs = append(pkgs, stdlib...)
 	}
-	log.Debugf("Built package set for %s", runtime.Version())
+	log.Debugf("Built package set")
 	return &packages.DriverResponse{
 		Packages: pkgs,
 		Roots:    roots,

--- a/tools/driver/test/BUILD
+++ b/tools/driver/test/BUILD
@@ -7,15 +7,16 @@ gentest(
     cmd = [
         'export PLZ_GOPACKAGESDRIVER_SEARCHDIR="$TMP_DIR"',
         'export GOPACKAGESDRIVER="$TOOLS_DRIVER"',
-        '"$TOOLS_GOSEC" --exclude G104,G304,G307 tools/driver/packages',
+        '"$TOOLS_GOSEC" --exclude G104,G304,G307 tools/driver/packages/... | tee $OUT',
     ],
+    outs = ["gosec_test.txt"],
     needs_transitive_deps = True,
     no_test_output = True,
     requires = [
         "go",
         "go_src",
     ],
-    test_cmd = "true",
+    test_cmd = "cat $TEST",
     tools = {
         "driver": ["//tools/driver:plz-gopackagesdriver"],
         "gosec": ["//third_party/binary:gosec"],


### PR DESCRIPTION
Also, upgrade gosec, and make sure the e2e test is actually doing something.