### PR TITLE
allow package driver to work on test files

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -847,6 +847,21 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         import_path = "main",
         _generate_pkg_info = False,
     )
+    provides = {
+        'go': lib_rule,
+    }
+    if CONFIG.GO.PKG_INFO:
+        pkg_info = _go_pkg_info(
+            name = name,
+            srcs = srcs + (resources or []),
+            package = test_package,
+            test_only = True,
+            include_tests = True,
+            visibility = visibility,
+            importconfig = import_config,
+        )
+        deps += [pkg_info]
+        provides["pkg_info"] = pkg_info
     cmds, tools = _go_binary_cmds(name, static=static, definitions=definitions, gcov=cgo, test=True)
 
 
@@ -913,6 +928,7 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
         output_is_complete = True,
         pre_build = _collect_linker_flags(static, definitions),
         env = env,
+        provides = provides,
     )
 
 
@@ -1013,7 +1029,24 @@ def go_benchmark(name:str, srcs:list, resources:list=None, data:list|dict=None, 
         labels = labels,
         test_only = test_only,
         import_path="main",
+        _generate_pkg_info = False,
     )
+    provides = {
+        'go': lib_rule,
+    }
+    if CONFIG.GO.PKG_INFO:
+        pkg_info = _go_pkg_info(
+            name = name,
+            srcs = srcs + (resources or []),
+            package = test_package,
+            test_only = True,
+            include_tests = True,
+            visibility = visibility,
+            importconfig = import_config,
+        )
+        deps += [pkg_info]
+        provides["pkg_info"] = pkg_info
+
     cmds, tools = _go_binary_cmds(name, static=static, definitions=definitions, gcov=cgo, test=True)
 
     return build_rule(
@@ -1035,6 +1068,7 @@ def go_benchmark(name:str, srcs:list, resources:list=None, data:list|dict=None, 
         output_is_complete=True,
         test_only=test_only,
         pre_build = _collect_linker_flags(static, definitions),
+        provides = provides,
     )
 
 def go_test_main(name:str, srcs:list, test_package:str="", test_only:bool=False, external=False,
@@ -1616,7 +1650,8 @@ def _go_modinfo(name:str, test_only:bool=False, deps:list):
 
 
 def _go_pkg_info(name:str, srcs:list, visibility:list, importconfig:str=None, import_path:str="", package:str="",
-                 module:str="", subrepo:str="", test_only:bool=False, install:list=[], large_package:bool=False):
+                 module:str="", subrepo:str="", test_only:bool=False, install:list=[], large_package:bool=False,
+                 include_tests:bool=False):
     """Internal-only function for generating the pkg_info files"""
     install_flags = ""
     for i in install:
@@ -1638,6 +1673,8 @@ def _go_pkg_info(name:str, srcs:list, visibility:list, importconfig:str=None, im
             cmd = f"{cmd} -s {subrepo}"
         if module:
             cmd = f"{cmd} --mod {module}"
+        if include_tests:
+            cmd = f"{cmd} -t"
     return build_rule(
         name = name,
         tag = "pkg_info",

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1029,7 +1029,6 @@ def go_benchmark(name:str, srcs:list, resources:list=None, data:list|dict=None, 
         labels = labels,
         test_only = test_only,
         import_path="main",
-        _generate_pkg_info = False,
     )
     provides = {
         'go': lib_rule,

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -234,51 +234,117 @@ func loadPackageInfo(files []string, mode packages.LoadMode) ([]*packages.Packag
 		return []*packages.Package{}, nil
 	}
 
-	r1, w1, err := os.Pipe()
+	// Pipes for whatinputs -> [deps, filter]
+	whatinputsR, whatinputsW, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
-	r2, w2, err := os.Pipe()
+	depsInR, depsInW, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
-	// N.B. deliberate not to close these here, they happen exactly when needed.
+	filterInR, filterInW, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Pipes for [deps, filter] -> build
+	depsOutR, depsOutW, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	filterOutR, filterOutW, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	buildInR, buildInW, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
 	whatinputs := plz("query", "whatinputs", "--ignore_unknown", "--hidden", "-")
 	whatinputs.Stdin = strings.NewReader(strings.Join(files, "\n"))
-	whatinputs.Stdout = w1
-	args := []string{"query", "deps", "-", "--hidden", "-i", "go_pkg_info", "-i", "go_src"}
+	whatinputs.Stdout = whatinputsW
+
+	args := []string{"-", "--hidden", "-i", "go_pkg_info", "-i", "go_src"}
 	if (mode & packages.NeedExportFile) != 0 {
 		args = append(args, "-i", "go")
 	}
-	deps := plz(args...)
-	deps.Stdin = r1
-	deps.Stdout = w2
+	deps := plz(append([]string{"query", "deps"}, args...)...)
+	deps.Stdin = depsInR
+	deps.Stdout = depsOutW
+
+	filter := plz(append([]string{"query", "filter"}, args...)...)
+	filter.Stdin = filterInR
+	filter.Stdout = filterOutW
+
 	build := plz("build", "-")
-	build.Stdin = r2
+	build.Stdin = buildInR
 	build.Stdout = &bytes.Buffer{}
+
 	if err := whatinputs.Start(); err != nil {
 		return nil, err
 	} else if err := deps.Start(); err != nil {
 		return nil, err
+	} else if err := filter.Start(); err != nil {
+		return nil, err
 	} else if err := build.Start(); err != nil {
 		return nil, err
 	}
+
+	// Duplicate whatinputs output to deps and filter
+	go func() {
+		defer depsInW.Close()
+		defer filterInW.Close()
+		io.Copy(io.MultiWriter(depsInW, filterInW), whatinputsR)
+	}()
+
+	// Merge deps and filter outputs to build input
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		io.Copy(buildInW, depsOutR)
+	}()
+	go func() {
+		defer wg.Done()
+		io.Copy(buildInW, filterOutR)
+	}()
+	go func() {
+		wg.Wait()
+		buildInW.Close()
+	}()
+
 	log.Debug("Waiting for plz query whatinputs...")
 	if err := whatinputs.Wait(); err != nil {
 		return nil, handleSubprocessErr(whatinputs, err)
 	}
-	w1.Close()
-	r1.Close()
+	whatinputsW.Close()
+
 	log.Debug("Waiting for plz query deps...")
 	if err := deps.Wait(); err != nil {
 		return nil, handleSubprocessErr(deps, err)
 	}
-	w2.Close()
-	r2.Close()
+	depsOutW.Close()
+
+	log.Debug("Waiting for plz query filter...")
+	if err := filter.Wait(); err != nil {
+		return nil, handleSubprocessErr(filter, err)
+	}
+	filterOutW.Close()
+
 	log.Debug("Waiting for plz build...")
 	if err := build.Wait(); err != nil {
 		return nil, handleSubprocessErr(build, err)
 	}
+
+	whatinputsR.Close()
+	depsInR.Close()
+	filterInR.Close()
+	depsOutR.Close()
+	filterOutR.Close()
+	buildInR.Close()
+
 	// Now we can read all the package info files from the build process' stdout.
 	return loadPackageInfoFiles(strings.Fields(strings.TrimSpace(build.Stdout.(*bytes.Buffer).String())))
 }

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -301,15 +302,20 @@ func loadPackageInfo(files []string, mode packages.LoadMode) ([]*packages.Packag
 
 	// Merge deps and filter outputs to build input
 	var wg sync.WaitGroup
+	var mu sync.Mutex
 	wg.Add(2)
-	go func() {
+	copyLines := func(r io.Reader) {
 		defer wg.Done()
-		io.Copy(buildInW, depsOutR)
-	}()
-	go func() {
-		defer wg.Done()
-		io.Copy(buildInW, filterOutR)
-	}()
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			mu.Lock()
+			buildInW.Write(scanner.Bytes())
+			buildInW.Write([]byte{'\n'})
+			mu.Unlock()
+		}
+	}
+	go copyLines(depsOutR)
+	go copyLines(filterOutR)
 	go func() {
 		wg.Wait()
 		buildInW.Close()

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -130,10 +130,12 @@ func createPackage(pkgPath, pkgDir, subrepo, module string) (*packages.Package, 
 // FromBuildPackage creates a packages Package from a build Package.
 func FromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Package {
 	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
-	imports :=slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
+	imports := slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
 	name := pkg.Name
 	id := pkg.ImportPath
 	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
+		// In please we may have an external test target and an internal test within the same please package.
+		// To ensure they have different go package import paths we appending to the name and id.
 		name += "_test"
 		id += "_test"
 	}

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -8,7 +8,6 @@ import (
 	"go/build"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,7 +19,7 @@ import (
 )
 
 // WritePackageInfo writes a series of package info files to the given file.
-func WritePackageInfo(importPath string, srcRoot, importconfig string, imports map[string]string, installPkgs []string, subrepo, module string, w io.Writer) error {
+func WritePackageInfo(importPath string, srcRoot, importconfig string, imports map[string]string, installPkgs []string, subrepo, module string, includeTests bool, w io.Writer) error {
 	// Discover all Go files in the module
 	goFiles := map[string][]string{}
 	module = modulePath(module, importPath)
@@ -30,7 +29,7 @@ func WritePackageInfo(importPath string, srcRoot, importconfig string, imports m
 			return err
 		} else if name := d.Name(); name == "testdata" {
 			return filepath.SkipDir // Don't descend into testdata
-		} else if strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") {
+		} else if strings.HasSuffix(name, ".go") && (includeTests || !strings.HasSuffix(name, "_test.go")) {
 			dir := filepath.Dir(path)
 			goFiles[dir] = append(goFiles[dir], path)
 		}
@@ -130,20 +129,27 @@ func createPackage(pkgPath, pkgDir, subrepo, module string) (*packages.Package, 
 
 // FromBuildPackage creates a packages Package from a build Package.
 func FromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Package {
+	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
+	imports :=slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
+	name := pkg.Name
+	id := pkg.ImportPath
+	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
+		name += "_test"
+		id += "_test"
+	}
 	p := &packages.Package{
-		ID:              pkg.ImportPath,
-		Name:            pkg.Name,
-		PkgPath:         pkg.ImportPath,
-		GoFiles:         make([]string, len(pkg.GoFiles)),
-		CompiledGoFiles: make([]string, len(pkg.GoFiles)),
+		ID:              id,
+		Name:            name,
+		PkgPath:         id,
+		GoFiles:         make([]string, len(goFiles)),
+		CompiledGoFiles: make([]string, len(goFiles)),
 		OtherFiles:      mappend(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
 		EmbedPatterns:   pkg.EmbedPatterns,
-		Imports:         make(map[string]*packages.Package, len(pkg.Imports)),
+		Imports:         make(map[string]*packages.Package, len(imports)),
 	}
-	for i, file := range pkg.GoFiles {
+	for i, file := range goFiles {
 		if subrepo != "" {
 			// this is fairly nasty... there must be a better way of getting it without the pkg/ prefix
-			log.Printf("here %s | %s | %s | %s", subrepo, pkg.Dir, file, module)
 			dir := strings.TrimPrefix(pkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
 			dir = strings.TrimPrefix(strings.TrimPrefix(dir, "/"), module)
 			p.GoFiles[i] = filepath.Join(subrepo, dir, file)
@@ -153,7 +159,7 @@ func FromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Pack
 			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file)
 		}
 	}
-	for _, imp := range pkg.Imports {
+	for _, imp := range imports {
 		p.Imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
 	}
 	return p

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -73,11 +73,12 @@ var opts = struct {
 		} `positional-args:"true"`
 	} `command:"embed" alias:"e" description:"Generate embed config for a set of Go source files"`
 	PackageInfo struct {
-		ImportPath string            `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
-		Pkg        string            `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
-		ImportMap  map[string]string `short:"m" long:"import_map" description:"Existing map of imports"`
-		Subrepo    string            `short:"s" long:"subrepo" description:"Subrepo root that this package is within"`
-		Module     string            `long:"mod" description:"The module this is within, if present"`
+		ImportPath   string            `short:"i" long:"import_path" description:"Go import path (e.g. github.com/please-build/go-rules)"`
+		Pkg          string            `long:"pkg" env:"PKG_DIR" description:"Package that we're in within the repo"`
+		ImportMap    map[string]string `short:"m" long:"import_map" description:"Existing map of imports"`
+		Subrepo      string            `short:"s" long:"subrepo" description:"Subrepo root that this package is within"`
+		Module       string            `long:"mod" description:"The module this is within, if present"`
+		IncludeTests bool              `short:"t" long:"include_tests" description:"Whether to include test files"`
 	} `command:"package_info" alias:"p" description:"Creates an info file about a Go package"`
 	ModuleInfo struct {
 		ModulePath   string   `short:"m" long:"module_path" required:"true" description:"Import path of the module in question"`
@@ -177,14 +178,14 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, pi.Pkg, "", pi.ImportMap, nil, pi.Subrepo, pi.Module, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.ImportPath, pi.Pkg, "", pi.ImportMap, nil, pi.Subrepo, pi.Module, pi.IncludeTests, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Srcs, mi.ImportConfig, nil, mi.Packages, "", "", os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Srcs, mi.ImportConfig, nil, mi.Packages, "", "", false, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0


### PR DESCRIPTION
Previously go_test targets didn't export a package info file. Now they do.

The package driver also now includes both the inputs of go files and the deps of the inputs of go files which have package info labels.

Fixes #347 