### PR TITLE
Generate coverage data if any tests fail

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -874,10 +874,11 @@ def go_test(name:str, srcs:list, resources:list=None, data:list|dict=None, deps:
     if CONFIG.BUILD_CONFIG == 'cover':
         if CONFIG.GO.GO_COVDATA_TOOL:
             test_tools["covdata"] = CONFIG.GO.GO_COVDATA_TOOL
-            test_cmd += " && $TOOLS_COVDATA textfmt -i=. -o=$COVERAGE_FILE"
+            covdata_cmd = "$TOOLS_COVDATA"
         else:
             test_tools["go"] = CONFIG.GO.GO_TOOL
-            test_cmd += " && $TOOLS_GO tool covdata textfmt -i=. -o=$COVERAGE_FILE"
+            covdata_cmd = "$TOOLS_GO tool covdata"
+        test_cmd += f"; status=$?; {covdata_cmd} textfmt -i=. -o=$COVERAGE_FILE; exit $status"
 
     debug_cmd, debug_data, debug_tools = _debug_cmd(
         name = name,


### PR DESCRIPTION
## Problem
Coverage data is not generated if any tests fail.

## Solution
Always run `go tool covdata` (or `CONFIG.GO.GO_COVDATA_TOOL`), even if `$TEST` exits with a non-zero code.