### PR TITLE
Ensure trailing slash on OUT_DIR

### DIFF
--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -99,7 +99,9 @@ def cgo_library(
             'h': [subdir2 + '_cgo_export.h'],
         },
         cmd = ' && '.join([
-            (f'OUT_DIR="$TMP_DIR/{subdir}" && mkdir -p "$OUT_DIR"') if subdir else 'OUT_DIR="$TMP_DIR"',
+            f'OUT_DIR="$TMP_DIR/{subdir}"' if subdir else 'OUT_DIR="$TMP_DIR"',
+            f'OUT_DIR=${OUT_DIR%/}/',
+            'mkdir -p "$OUT_DIR"' if subdir else 'true',
             'cd $PKG_DIR/' + subdir,
             f'$TOOL tool cgo -objdir "$OUT_DIR" -importpath {import_path} -trimpath "$TMP_DIR" -- {compiler_flags_cmd} *.go',
             # Remove the .o file which BSD sed gets upset about in the next command

--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -99,9 +99,7 @@ def cgo_library(
             'h': [subdir2 + '_cgo_export.h'],
         },
         cmd = ' && '.join([
-            f'OUT_DIR="$TMP_DIR/{subdir}"' if subdir else 'OUT_DIR="$TMP_DIR"',
-            f'OUT_DIR=${OUT_DIR%/}/',
-            'mkdir -p "$OUT_DIR"' if subdir else 'true',
+            f'OUT_DIR="$TMP_DIR/{subdir2}" && mkdir -p "$OUT_DIR"' if subdir else 'OUT_DIR="$TMP_DIR/"',
             'cd $PKG_DIR/' + subdir,
             f'$TOOL tool cgo -objdir "$OUT_DIR" -importpath {import_path} -trimpath "$TMP_DIR" -- {compiler_flags_cmd} *.go',
             # Remove the .o file which BSD sed gets upset about in the next command


### PR DESCRIPTION
When a git worktree is placed under /tmp, and when a plz build //some/cgo/target command is run under this tmp subdir, /tmp is set to read only. When cgo attempt to write a file such as /tmp/plz_sandbox_cgo_5.o, a fatal error will be raised. This PR ensures the objdir value always ends with a slash so any files cgo writes will be put into the sandbox properly.

Reproduction

```
$ git worktree add -b test /tmp/test master
$ cd /tmp/test
$ plz build ///third_party/go/github.com_confluentinc_confluent-kafka-go_v2//kafka:_kafka#cgo
Build stopped after 21.51s. 1 target failed:
    ///third_party/go/github.com_confluentinc_confluent-kafka-go_v2//kafka:_kafka#cgo
Error building target ///third_party/go/github.com_confluentinc_confluent-kafka-go_v2//kafka:_kafka#cgo: exit status 2
Assembler messages:
Fatal error: can't create /tmp/plz_sandbox_cgo_16.o: Read-only file system
Assembler messages:
Fatal error: can't create /tmp/plz_sandbox_cgo_15.o: Read-only file system
```