### PR TITLE
refactor: split packageinfo.WritePackageInfo into one function for modules and one for packages

### DIFF
--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -421,7 +421,7 @@ func loadStdlibPackages() ([]*packages.Package, error) {
 		} else if err != nil {
 			return nil, err
 		}
-		pkgs = append(pkgs, packageinfo.FromBuildPackage(pkg, "", ""))
+		pkgs = append(pkgs, packageinfo.FromBuildPackageForModule(pkg, "", ""))
 	}
 	return pkgs, nil
 }

--- a/tools/driver/packages/packages.go
+++ b/tools/driver/packages/packages.go
@@ -421,7 +421,7 @@ func loadStdlibPackages() ([]*packages.Package, error) {
 		} else if err != nil {
 			return nil, err
 		}
-		pkgs = append(pkgs, packageinfo.FromBuildPackageForModule(pkg, "", ""))
+		pkgs = append(pkgs, packageinfo.FromBuildPackageForModule(pkg))
 	}
 	return pkgs, nil
 }

--- a/tools/please_go/packageinfo/BUILD
+++ b/tools/please_go/packageinfo/BUILD
@@ -8,12 +8,24 @@ filegroup(
 
 go_library(
     name = "packageinfo",
-    srcs = glob(["*.go"]),
+    srcs = glob(
+        ["*.go"],
+        exclude = ["*_test.go"],
+    ),
     visibility = [
         "//tools/driver/...",
         "//tools/please_go/...",
     ],
+    deps = ["///third_party/go/golang.org_x_tools//go/packages"],
+)
+
+go_test(
+    name = "test",
+    srcs = glob(["*_test.go"]),
     deps = [
+        ":packageinfo",
+        "///third_party/go/github.com_stretchr_testify//assert",
+        "///third_party/go/github.com_stretchr_testify//require",
         "///third_party/go/golang.org_x_tools//go/packages",
     ],
 )

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -15,17 +15,16 @@ import (
 )
 
 // WriteModuleInfo writes a series of package info files to the given file.
-func WriteModuleInfo(importPath string, srcRoot, importconfig string, imports map[string]string, installPkgs []string, subrepo, module string, includeTests bool, w io.Writer) error {
+func WriteModuleInfo(importPath string, srcRoot, importconfig string, installPkgs []string, w io.Writer) error {
 	// Discover all Go files in the module
 	goFiles := map[string][]string{}
-	module = modulePath(module, importPath)
 
 	walkDirFunc := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		} else if name := d.Name(); name == "testdata" {
 			return filepath.SkipDir // Don't descend into testdata
-		} else if strings.HasSuffix(name, ".go") && (includeTests || !strings.HasSuffix(name, "_test.go")) {
+		} else if strings.HasSuffix(name, ".go") && (!strings.HasSuffix(name, "_test.go")) {
 			dir := filepath.Dir(path)
 			goFiles[dir] = append(goFiles[dir], path)
 		}
@@ -48,41 +47,29 @@ func WriteModuleInfo(importPath string, srcRoot, importconfig string, imports ma
 			return fmt.Errorf("failed to read module dir: %w", err)
 		}
 	}
-	if importconfig != "" {
-		m, err := loadImportConfig(importconfig)
-		if err != nil {
-			return fmt.Errorf("failed to read importconfig: %w", err)
-		}
-		imports = m
+	imports, err := loadImportConfig(importconfig)
+	if err != nil {
+		return fmt.Errorf("failed to read importconfig: %w", err)
 	}
+
 	pkgs := make([]*packages.Package, 0, len(goFiles))
 	for dir := range goFiles {
 		pkgDir := strings.TrimPrefix(strings.TrimPrefix(dir, srcRoot), "/")
-		pkg, err := createPackage(filepath.Join(importPath, pkgDir), dir, subrepo, module)
+		pkg, err := createPackage(filepath.Join(importPath, pkgDir), dir, "", importPath)
 		if _, ok := err.(*build.NoGoError); ok {
 			continue // Don't really care, this happens sometimes for modules
 		} else if err != nil {
 			return fmt.Errorf("failed to import directory %s: %w", dir, err)
 		}
-		if subrepo != "" {
-			_, pkgPath, ok := strings.Cut(imports[pkg.PkgPath], pkg.PkgPath)
-			if !ok {
-				return fmt.Errorf("Cannot determine export file path for package %s from %s", pkg.PkgPath, imports[pkg.PkgPath])
-			}
-			// This is a really gross hack to sneak both paths through the one field.
-			pkg.ExportFile = filepath.Join(subrepo, pkgPath) + "|" + imports[pkg.PkgPath]
-		} else {
-			pkg.ExportFile = imports[pkg.PkgPath]
-		}
+		pkg.ExportFile = imports[pkg.PkgPath]
 		pkgs = append(pkgs, pkg)
 	}
 	// If we're doing the stdlib, limit it to just things in the importconfig (i.e. no cmd/ packages)
-	if importconfig != "" {
-		pkgs = slices.DeleteFunc(pkgs, func(pkg *packages.Package) bool {
-			_, present := imports[pkg.PkgPath]
-			return !present
-		})
-	}
+	pkgs = slices.DeleteFunc(pkgs, func(pkg *packages.Package) bool {
+		_, present := imports[pkg.PkgPath]
+		return !present
+	})
+
 	// Vendor packages. They aren't identified by the original imports but we know what they are now.
 	vendorised := map[string]*packages.Package{}
 	for _, pkg := range pkgs {

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -63,7 +62,7 @@ func WriteModuleInfo(importPath string, srcRoot, importconfig string, installPkg
 		} else if err != nil {
 			return fmt.Errorf("failed to import directory %s: %w", dir, err)
 		}
-		pkg := FromBuildPackageForModule(bpkg, "", importPath)
+		pkg := FromBuildPackageForModule(bpkg)
 
 		pkg.ExportFile = imports[pkg.PkgPath]
 		pkgs = append(pkgs, pkg)
@@ -118,7 +117,7 @@ func loadImportConfig(filename string) (map[string]string, error) {
 }
 
 // FromBuildPackageForModule creates a packages Package from a build Package for a module.
-func FromBuildPackageForModule(pkg *build.Package, subrepo, module string) *packages.Package {
+func FromBuildPackageForModule(pkg *build.Package) *packages.Package {
 	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
 	imports := slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
 	name := pkg.Name
@@ -140,16 +139,8 @@ func FromBuildPackageForModule(pkg *build.Package, subrepo, module string) *pack
 		Imports:         make(map[string]*packages.Package, len(imports)),
 	}
 	for i, file := range goFiles {
-		if subrepo != "" {
-			// this is fairly nasty... there must be a better way of getting it without the pkg/ prefix
-			dir := strings.TrimPrefix(pkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
-			dir = strings.TrimPrefix(strings.TrimPrefix(dir, "/"), module)
-			p.GoFiles[i] = filepath.Join(subrepo, dir, file)
-			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file) // Stash this here for later
-		} else {
-			p.GoFiles[i] = filepath.Join(pkg.Dir, file)
-			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file)
-		}
+		p.GoFiles[i] = filepath.Join(pkg.Dir, file)
+		p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file)
 	}
 	for _, imp := range imports {
 		p.Imports[imp] = &packages.Package{ID: imp, PkgPath: imp}

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -142,7 +142,7 @@ func FromBuildPackageForModule(pkg *build.Package) *packages.Package {
 		PkgPath:         id,
 		GoFiles:         goFiles,
 		CompiledGoFiles: goFiles,
-		OtherFiles:      mappend(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
+		OtherFiles:      slices.Concat(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
 		EmbedPatterns:   pkg.EmbedPatterns,
 		Imports:         imports,
 	}

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -56,12 +56,14 @@ func WriteModuleInfo(importPath string, srcRoot, importconfig string, installPkg
 	pkgs := make([]*packages.Package, 0, len(goFiles))
 	for dir := range goFiles {
 		pkgDir := strings.TrimPrefix(strings.TrimPrefix(dir, srcRoot), "/")
-		pkg, err := createPackage(filepath.Join(importPath, pkgDir), dir, "", importPath)
+		bpkg, err := buildPackage(filepath.Join(importPath, pkgDir), dir)
 		if _, ok := err.(*build.NoGoError); ok {
 			continue // Don't really care, this happens sometimes for modules
 		} else if err != nil {
 			return fmt.Errorf("failed to import directory %s: %w", dir, err)
 		}
+		pkg := FromBuildPackage(bpkg, "", importPath)
+
 		pkg.ExportFile = imports[pkg.PkgPath]
 		pkgs = append(pkgs, pkg)
 	}

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -1,0 +1,107 @@
+package packageinfo
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// WriteModuleInfo writes a series of package info files to the given file.
+func WriteModuleInfo(importPath string, srcRoot, importconfig string, imports map[string]string, installPkgs []string, subrepo, module string, includeTests bool, w io.Writer) error {
+	// Discover all Go files in the module
+	goFiles := map[string][]string{}
+	module = modulePath(module, importPath)
+
+	walkDirFunc := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		} else if name := d.Name(); name == "testdata" {
+			return filepath.SkipDir // Don't descend into testdata
+		} else if strings.HasSuffix(name, ".go") && (includeTests || !strings.HasSuffix(name, "_test.go")) {
+			dir := filepath.Dir(path)
+			goFiles[dir] = append(goFiles[dir], path)
+		}
+		return nil
+	}
+	// Check install packages first
+	for _, pkg := range installPkgs {
+		if strings.Contains(pkg, "...") {
+			pkg = strings.TrimSuffix(pkg, "...")
+			if err := filepath.WalkDir(filepath.Join(srcRoot, pkg), walkDirFunc); err != nil {
+				return fmt.Errorf("failed to read module dir: %w", err)
+			}
+		} else {
+			dir := filepath.Join(srcRoot, pkg)
+			goFiles[dir] = append(goFiles[dir], filepath.Join(srcRoot, pkg))
+		}
+	}
+	if len(installPkgs) == 0 {
+		if err := filepath.WalkDir(srcRoot, walkDirFunc); err != nil {
+			return fmt.Errorf("failed to read module dir: %w", err)
+		}
+	}
+	if importconfig != "" {
+		m, err := loadImportConfig(importconfig)
+		if err != nil {
+			return fmt.Errorf("failed to read importconfig: %w", err)
+		}
+		imports = m
+	}
+	pkgs := make([]*packages.Package, 0, len(goFiles))
+	for dir := range goFiles {
+		pkgDir := strings.TrimPrefix(strings.TrimPrefix(dir, srcRoot), "/")
+		pkg, err := createPackage(filepath.Join(importPath, pkgDir), dir, subrepo, module)
+		if _, ok := err.(*build.NoGoError); ok {
+			continue // Don't really care, this happens sometimes for modules
+		} else if err != nil {
+			return fmt.Errorf("failed to import directory %s: %w", dir, err)
+		}
+		if subrepo != "" {
+			_, pkgPath, ok := strings.Cut(imports[pkg.PkgPath], pkg.PkgPath)
+			if !ok {
+				return fmt.Errorf("Cannot determine export file path for package %s from %s", pkg.PkgPath, imports[pkg.PkgPath])
+			}
+			// This is a really gross hack to sneak both paths through the one field.
+			pkg.ExportFile = filepath.Join(subrepo, pkgPath) + "|" + imports[pkg.PkgPath]
+		} else {
+			pkg.ExportFile = imports[pkg.PkgPath]
+		}
+		pkgs = append(pkgs, pkg)
+	}
+	// If we're doing the stdlib, limit it to just things in the importconfig (i.e. no cmd/ packages)
+	if importconfig != "" {
+		pkgs = slices.DeleteFunc(pkgs, func(pkg *packages.Package) bool {
+			_, present := imports[pkg.PkgPath]
+			return !present
+		})
+	}
+	// Vendor packages. They aren't identified by the original imports but we know what they are now.
+	vendorised := map[string]*packages.Package{}
+	for _, pkg := range pkgs {
+		if strings.HasPrefix(pkg.PkgPath, "vendor/") {
+			vendorised[strings.TrimPrefix(pkg.PkgPath, "vendor/")] = pkg
+		}
+	}
+	for _, pkg := range pkgs {
+		for k := range pkg.Imports {
+			if v, present := vendorised[k]; present {
+				pkg.Imports[k] = v
+			}
+		}
+	}
+	// Ensure output is deterministic
+	sort.Slice(pkgs, func(i, j int) bool {
+		return pkgs[i].ID < pkgs[j].ID
+	})
+	e := json.NewEncoder(w)
+	e.SetIndent("", "  ")
+	return e.Encode(pkgs)
+}

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -6,6 +6,7 @@ import (
 	"go/build"
 	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -91,4 +92,24 @@ func WriteModuleInfo(importPath string, srcRoot, importconfig string, installPkg
 	e := json.NewEncoder(w)
 	e.SetIndent("", "  ")
 	return e.Encode(pkgs)
+}
+
+// loadImportConfig reads the given importconfig file and produces a map of package name -> export path
+func loadImportConfig(filename string) (map[string]string, error) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(b), "\n")
+	m := make(map[string]string, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "packagefile ") {
+			pkg, exportFile, found := strings.Cut(strings.TrimPrefix(line, "packagefile "), "=")
+			if !found {
+				return nil, fmt.Errorf("unknown syntax for line: %s", line)
+			}
+			m[pkg] = exportFile
+		}
+	}
+	return m, nil
 }

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -76,8 +76,8 @@ func WriteModuleInfo(importPath string, srcRoot, importconfig string, installPkg
 	// Vendor packages. They aren't identified by the original imports but we know what they are now.
 	vendorised := map[string]*packages.Package{}
 	for _, pkg := range pkgs {
-		if strings.HasPrefix(pkg.PkgPath, "vendor/") {
-			vendorised[strings.TrimPrefix(pkg.PkgPath, "vendor/")] = pkg
+		if after, ok := strings.CutPrefix(pkg.PkgPath, "vendor/"); ok {
+			vendorised[after] = pkg
 		}
 	}
 	for _, pkg := range pkgs {
@@ -105,8 +105,8 @@ func loadImportConfig(filename string) (map[string]string, error) {
 	lines := strings.Split(string(b), "\n")
 	m := make(map[string]string, len(lines))
 	for _, line := range lines {
-		if strings.HasPrefix(line, "packagefile ") {
-			pkg, exportFile, found := strings.Cut(strings.TrimPrefix(line, "packagefile "), "=")
+		if after, ok := strings.CutPrefix(line, "packagefile "); ok {
+			pkg, exportFile, found := strings.Cut(after, "=")
 			if !found {
 				return nil, fmt.Errorf("unknown syntax for line: %s", line)
 			}

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -117,20 +117,20 @@ func loadImportConfig(filename string) (map[string]string, error) {
 }
 
 // FromBuildPackageForModule creates a packages Package from a build Package for a module.
-func FromBuildPackageForModule(pkg *build.Package) *packages.Package {
-	goFiles := make([]string, len(pkg.GoFiles)+len(pkg.TestGoFiles)+len(pkg.XTestGoFiles))
-	for i, file := range pkg.GoFiles {
-		goFiles[i] = filepath.Join(pkg.Dir, file)
+func FromBuildPackageForModule(bpkg *build.Package) *packages.Package {
+	goFiles := make([]string, len(bpkg.GoFiles)+len(bpkg.TestGoFiles)+len(bpkg.XTestGoFiles))
+	for i, file := range bpkg.GoFiles {
+		goFiles[i] = filepath.Join(bpkg.Dir, file)
 	}
 
-	imports := make(map[string]*packages.Package, len(pkg.Imports)+len(pkg.TestImports)+len(pkg.XTestImports))
-	for _, imp := range pkg.Imports {
+	imports := make(map[string]*packages.Package, len(bpkg.Imports)+len(bpkg.TestImports)+len(bpkg.XTestImports))
+	for _, imp := range bpkg.Imports {
 		imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
 	}
 
-	name := pkg.Name
-	id := pkg.ImportPath
-	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
+	name := bpkg.Name
+	id := bpkg.ImportPath
+	if len(bpkg.XTestGoFiles) > 0 || len(bpkg.XTestImports) > 0 {
 		// In please we may have an external test target and an internal test within the same please package.
 		// To ensure they have different go package import paths we appending to the name and id.
 		name += "_test"
@@ -142,8 +142,8 @@ func FromBuildPackageForModule(pkg *build.Package) *packages.Package {
 		PkgPath:         id,
 		GoFiles:         goFiles,
 		CompiledGoFiles: goFiles,
-		OtherFiles:      slices.Concat(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
-		EmbedPatterns:   pkg.EmbedPatterns,
+		OtherFiles:      slices.Concat(bpkg.CFiles, bpkg.CXXFiles, bpkg.MFiles, bpkg.HFiles, bpkg.SFiles, bpkg.SwigFiles, bpkg.SwigCXXFiles, bpkg.SysoFiles),
+		EmbedPatterns:   bpkg.EmbedPatterns,
 		Imports:         imports,
 	}
 }

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -118,8 +118,16 @@ func loadImportConfig(filename string) (map[string]string, error) {
 
 // FromBuildPackageForModule creates a packages Package from a build Package for a module.
 func FromBuildPackageForModule(pkg *build.Package) *packages.Package {
-	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
-	imports := slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
+	goFiles := make([]string, len(pkg.GoFiles)+len(pkg.TestGoFiles)+len(pkg.XTestGoFiles))
+	for i, file := range pkg.GoFiles {
+		goFiles[i] = filepath.Join(pkg.Dir, file)
+	}
+
+	imports := make(map[string]*packages.Package, len(pkg.Imports)+len(pkg.TestImports)+len(pkg.XTestImports))
+	for _, imp := range pkg.Imports {
+		imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
+	}
+
 	name := pkg.Name
 	id := pkg.ImportPath
 	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
@@ -128,22 +136,14 @@ func FromBuildPackageForModule(pkg *build.Package) *packages.Package {
 		name += "_test"
 		id += "_test"
 	}
-	p := &packages.Package{
+	return &packages.Package{
 		ID:              id,
 		Name:            name,
 		PkgPath:         id,
-		GoFiles:         make([]string, len(goFiles)),
-		CompiledGoFiles: make([]string, len(goFiles)),
+		GoFiles:         goFiles,
+		CompiledGoFiles: goFiles,
 		OtherFiles:      mappend(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
 		EmbedPatterns:   pkg.EmbedPatterns,
-		Imports:         make(map[string]*packages.Package, len(imports)),
+		Imports:         imports,
 	}
-	for i, file := range goFiles {
-		p.GoFiles[i] = filepath.Join(pkg.Dir, file)
-		p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file)
-	}
-	for _, imp := range imports {
-		p.Imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
-	}
-	return p
 }

--- a/tools/please_go/packageinfo/moduleinfo.go
+++ b/tools/please_go/packageinfo/moduleinfo.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -62,7 +63,7 @@ func WriteModuleInfo(importPath string, srcRoot, importconfig string, installPkg
 		} else if err != nil {
 			return fmt.Errorf("failed to import directory %s: %w", dir, err)
 		}
-		pkg := FromBuildPackage(bpkg, "", importPath)
+		pkg := FromBuildPackageForModule(bpkg, "", importPath)
 
 		pkg.ExportFile = imports[pkg.PkgPath]
 		pkgs = append(pkgs, pkg)
@@ -114,4 +115,44 @@ func loadImportConfig(filename string) (map[string]string, error) {
 		}
 	}
 	return m, nil
+}
+
+// FromBuildPackageForModule creates a packages Package from a build Package for a module.
+func FromBuildPackageForModule(pkg *build.Package, subrepo, module string) *packages.Package {
+	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
+	imports := slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
+	name := pkg.Name
+	id := pkg.ImportPath
+	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
+		// In please we may have an external test target and an internal test within the same please package.
+		// To ensure they have different go package import paths we appending to the name and id.
+		name += "_test"
+		id += "_test"
+	}
+	p := &packages.Package{
+		ID:              id,
+		Name:            name,
+		PkgPath:         id,
+		GoFiles:         make([]string, len(goFiles)),
+		CompiledGoFiles: make([]string, len(goFiles)),
+		OtherFiles:      mappend(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
+		EmbedPatterns:   pkg.EmbedPatterns,
+		Imports:         make(map[string]*packages.Package, len(imports)),
+	}
+	for i, file := range goFiles {
+		if subrepo != "" {
+			// this is fairly nasty... there must be a better way of getting it without the pkg/ prefix
+			dir := strings.TrimPrefix(pkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
+			dir = strings.TrimPrefix(strings.TrimPrefix(dir, "/"), module)
+			p.GoFiles[i] = filepath.Join(subrepo, dir, file)
+			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file) // Stash this here for later
+		} else {
+			p.GoFiles[i] = filepath.Join(pkg.Dir, file)
+			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file)
+		}
+	}
+	for _, imp := range imports {
+		p.Imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
+	}
+	return p
 }

--- a/tools/please_go/packageinfo/moduleinfo_test.go
+++ b/tools/please_go/packageinfo/moduleinfo_test.go
@@ -44,10 +44,6 @@ func Hello() {
 		tmpDir,
 		icFile,
 		nil,
-		nil,
-		"",
-		"",
-		false,
 		&buf,
 	)
 	require.NoError(t, err)
@@ -99,10 +95,6 @@ func TestWriteModuleInfo_Filtering(t *testing.T) {
 		tmpDir,
 		icFile,
 		nil,
-		nil,
-		"",
-		"",
-		false,
 		&buf,
 	)
 	require.NoError(t, err)
@@ -151,10 +143,6 @@ packagefile github.com/example/bar=export/bar.a
 			tmpDir,
 			icFile,
 			nil, // installPkgs is nil
-			nil,
-			"",
-			"",
-			false,
 			&buf,
 		)
 		require.NoError(t, err)
@@ -176,11 +164,7 @@ packagefile github.com/example/bar=export/bar.a
 			"github.com/example",
 			tmpDir,
 			icFile,
-			nil,
 			[]string{"foo"},
-			"",
-			"",
-			false,
 			&buf,
 		)
 		require.NoError(t, err)
@@ -200,11 +184,7 @@ packagefile github.com/example/bar=export/bar.a
 			"github.com/example",
 			tmpDir,
 			icFile,
-			nil,
 			[]string{"foo/..."},
-			"",
-			"",
-			false,
 			&buf,
 		)
 		require.NoError(t, err)
@@ -250,10 +230,6 @@ import "github.com/example/lib"
 		tmpDir,
 		icFile,
 		nil,
-		nil,
-		"",
-		"",
-		false,
 		&buf,
 	)
 	require.NoError(t, err)

--- a/tools/please_go/packageinfo/moduleinfo_test.go
+++ b/tools/please_go/packageinfo/moduleinfo_test.go
@@ -1,0 +1,279 @@
+package packageinfo
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestWriteModuleInfo_Simple(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an importconfig file that preserves package "foo"
+	icFile := filepath.Join(tmpDir, "importconfig")
+	icContent := `packagefile github.com/example/foo=export/path/to/foo.a
+`
+	err := os.WriteFile(icFile, []byte(icContent), 0644)
+	require.NoError(t, err)
+
+	// Create a simple package "foo"
+	fooDir := filepath.Join(tmpDir, "foo")
+	err = os.MkdirAll(fooDir, 0755)
+	require.NoError(t, err)
+
+	fooSrc := `package foo
+
+import "fmt"
+
+func Hello() {
+	fmt.Println("hello")
+}
+`
+	err = os.WriteFile(filepath.Join(fooDir, "foo.go"), []byte(fooSrc), 0644)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = WriteModuleInfo(
+		"github.com/example",
+		tmpDir,
+		icFile,
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		&buf,
+	)
+	require.NoError(t, err)
+
+	var pkgs []*packages.Package
+	err = json.Unmarshal(buf.Bytes(), &pkgs)
+	require.NoError(t, err)
+
+	expected := []*packages.Package{
+		{
+			ID:              "github.com/example/foo",
+			Name:            "foo",
+			PkgPath:         "github.com/example/foo",
+			GoFiles:         []string{filepath.Join(fooDir, "foo.go")},
+			CompiledGoFiles: []string{filepath.Join(fooDir, "foo.go")},
+			ExportFile:      "export/path/to/foo.a",
+			Imports: map[string]*packages.Package{
+				"fmt": {
+					ID: "fmt",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, pkgs)
+}
+
+func TestWriteModuleInfo_Filtering(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an empty importconfig file
+	icFile := filepath.Join(tmpDir, "importconfig")
+	err := os.WriteFile(icFile, []byte{}, 0644)
+	require.NoError(t, err)
+
+	// Create package "foo"
+	fooDir := filepath.Join(tmpDir, "foo")
+	err = os.MkdirAll(fooDir, 0755)
+	require.NoError(t, err)
+
+	fooSrc := `package foo
+`
+	err = os.WriteFile(filepath.Join(fooDir, "foo.go"), []byte(fooSrc), 0644)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = WriteModuleInfo(
+		"github.com/example",
+		tmpDir,
+		icFile,
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		&buf,
+	)
+	require.NoError(t, err)
+
+	var pkgs []*packages.Package
+	err = json.Unmarshal(buf.Bytes(), &pkgs)
+	require.NoError(t, err)
+
+	// Since importconfig is empty, foo is not present in imports map,
+	// and slices.DeleteFunc will filter it out.
+	assert.Empty(t, pkgs)
+}
+
+func TestWriteModuleInfo_InstallPkgs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an importconfig file containing all possible packages
+	icFile := filepath.Join(tmpDir, "importconfig")
+	icContent := `packagefile github.com/example/foo=export/foo.a
+packagefile github.com/example/foo/sub=export/sub.a
+packagefile github.com/example/bar=export/bar.a
+`
+	err := os.WriteFile(icFile, []byte(icContent), 0644)
+	require.NoError(t, err)
+
+	// Create package "foo"
+	fooDir := filepath.Join(tmpDir, "foo")
+	require.NoError(t, os.MkdirAll(fooDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(fooDir, "foo.go"), []byte("package foo\n"), 0644))
+
+	// Create package "foo/sub"
+	fooSubDir := filepath.Join(fooDir, "sub")
+	require.NoError(t, os.MkdirAll(fooSubDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(fooSubDir, "sub.go"), []byte("package sub\n"), 0644))
+
+	// Create package "bar"
+	barDir := filepath.Join(tmpDir, "bar")
+	require.NoError(t, os.MkdirAll(barDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(barDir, "bar.go"), []byte("package bar\n"), 0644))
+
+	// 1. Without installPkgs, walking the entire tmpDir should return all 3 packages.
+	{
+		var buf bytes.Buffer
+		err := WriteModuleInfo(
+			"github.com/example",
+			tmpDir,
+			icFile,
+			nil, // installPkgs is nil
+			nil,
+			"",
+			"",
+			false,
+			&buf,
+		)
+		require.NoError(t, err)
+
+		var pkgs []*packages.Package
+		err = json.Unmarshal(buf.Bytes(), &pkgs)
+		require.NoError(t, err)
+
+		require.Len(t, pkgs, 3)
+		assert.Equal(t, "github.com/example/bar", pkgs[0].ID)
+		assert.Equal(t, "github.com/example/foo", pkgs[1].ID)
+		assert.Equal(t, "github.com/example/foo/sub", pkgs[2].ID)
+	}
+
+	// 2. With installPkgs = []string{"foo"}, only "foo" should be imported directly.
+	{
+		var buf bytes.Buffer
+		err := WriteModuleInfo(
+			"github.com/example",
+			tmpDir,
+			icFile,
+			nil,
+			[]string{"foo"},
+			"",
+			"",
+			false,
+			&buf,
+		)
+		require.NoError(t, err)
+
+		var pkgs []*packages.Package
+		err = json.Unmarshal(buf.Bytes(), &pkgs)
+		require.NoError(t, err)
+
+		require.Len(t, pkgs, 1)
+		assert.Equal(t, "github.com/example/foo", pkgs[0].ID)
+	}
+
+	// 3. With installPkgs = []string{"foo/..."}, it should recursively discover "foo" and "foo/sub" but still ignore "bar".
+	{
+		var buf bytes.Buffer
+		err := WriteModuleInfo(
+			"github.com/example",
+			tmpDir,
+			icFile,
+			nil,
+			[]string{"foo/..."},
+			"",
+			"",
+			false,
+			&buf,
+		)
+		require.NoError(t, err)
+
+		var pkgs []*packages.Package
+		err = json.Unmarshal(buf.Bytes(), &pkgs)
+		require.NoError(t, err)
+
+		require.Len(t, pkgs, 2)
+		assert.Equal(t, "github.com/example/foo", pkgs[0].ID)
+		assert.Equal(t, "github.com/example/foo/sub", pkgs[1].ID)
+	}
+}
+
+func TestWriteModuleInfo_Vendor(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an importconfig file containing both packages
+	icFile := filepath.Join(tmpDir, "importconfig")
+	icContent := `packagefile foo=export/foo.a
+packagefile vendor/github.com/example/lib=export/lib.a
+`
+	err := os.WriteFile(icFile, []byte(icContent), 0644)
+	require.NoError(t, err)
+
+	// Create package "foo" which imports "github.com/example/lib"
+	fooDir := filepath.Join(tmpDir, "foo")
+	require.NoError(t, os.MkdirAll(fooDir, 0755))
+	fooSrc := `package foo
+
+import "github.com/example/lib"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(fooDir, "foo.go"), []byte(fooSrc), 0644))
+
+	// Create vendor package "vendor/github.com/example/lib"
+	libDir := filepath.Join(tmpDir, "vendor", "github.com/example", "lib")
+	require.NoError(t, os.MkdirAll(libDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(libDir, "lib.go"), []byte("package lib\n"), 0644))
+
+	var buf bytes.Buffer
+	err = WriteModuleInfo(
+		"", // empty importPath for vendor directories
+		tmpDir,
+		icFile,
+		nil,
+		nil,
+		"",
+		"",
+		false,
+		&buf,
+	)
+	require.NoError(t, err)
+
+	var pkgs []*packages.Package
+	err = json.Unmarshal(buf.Bytes(), &pkgs)
+	require.NoError(t, err)
+
+	// Since we populated importconfig, both packages should survive.
+	// Output should be sorted by ID: "foo" first, then "vendor/github.com/example/lib"
+	require.Len(t, pkgs, 2)
+
+	fooPkg := pkgs[0]
+	libPkg := pkgs[1]
+
+	assert.Equal(t, "foo", fooPkg.ID)
+	assert.Equal(t, "vendor/github.com/example/lib", libPkg.ID)
+
+	// The "github.com/example/lib" import in "fooPkg" should have been resolved to the vendor package.
+	// Therefore, its ID should be "vendor/github.com/example/lib"
+	require.Contains(t, fooPkg.Imports, "github.com/example/lib")
+	assert.Equal(t, "vendor/github.com/example/lib", fooPkg.Imports["github.com/example/lib"].ID)
+}

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -91,9 +91,30 @@ func buildPackage(
 	return bpkg, nil
 }
 
-func fromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Package {
-	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
-	imports := slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
+func fromBuildPackage(
+	pkg *build.Package,
+	subrepo string,
+	module string,
+) *packages.Package {
+	goFiles := make([]string, len(pkg.GoFiles)+len(pkg.TestGoFiles)+len(pkg.XTestGoFiles))
+	compiledGoFiles := make([]string, len(goFiles))
+	for i, file := range slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles) {
+		if subrepo != "" {
+			// this is fairly nasty... there must be a better way of getting it without the pkg/ prefix
+			dir := strings.TrimPrefix(pkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
+			dir = strings.TrimPrefix(strings.TrimPrefix(dir, "/"), module)
+			goFiles[i] = filepath.Join(subrepo, dir, file)
+			compiledGoFiles[i] = filepath.Join(pkg.Dir, file) // Stash this here for later
+		} else {
+			goFiles[i] = filepath.Join(pkg.Dir, file)
+			compiledGoFiles[i] = filepath.Join(pkg.Dir, file)
+		}
+	}
+	imports := make(map[string]*packages.Package, len(pkg.Imports)+len(pkg.TestImports)+len(pkg.XTestImports))
+	for _, imp := range slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports) {
+		imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
+	}
+
 	name := pkg.Name
 	id := pkg.ImportPath
 	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
@@ -102,32 +123,16 @@ func fromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Pack
 		name += "_test"
 		id += "_test"
 	}
-	p := &packages.Package{
+	return &packages.Package{
 		ID:              id,
 		Name:            name,
 		PkgPath:         id,
-		GoFiles:         make([]string, len(goFiles)),
-		CompiledGoFiles: make([]string, len(goFiles)),
+		GoFiles:         goFiles,
+		CompiledGoFiles: compiledGoFiles,
 		OtherFiles:      mappend(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
 		EmbedPatterns:   pkg.EmbedPatterns,
-		Imports:         make(map[string]*packages.Package, len(imports)),
+		Imports:         imports,
 	}
-	for i, file := range goFiles {
-		if subrepo != "" {
-			// this is fairly nasty... there must be a better way of getting it without the pkg/ prefix
-			dir := strings.TrimPrefix(pkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
-			dir = strings.TrimPrefix(strings.TrimPrefix(dir, "/"), module)
-			p.GoFiles[i] = filepath.Join(subrepo, dir, file)
-			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file) // Stash this here for later
-		} else {
-			p.GoFiles[i] = filepath.Join(pkg.Dir, file)
-			p.CompiledGoFiles[i] = filepath.Join(pkg.Dir, file)
-		}
-	}
-	for _, imp := range imports {
-		p.Imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
-	}
-	return p
 }
 
 // mappend appends multiple slices together.

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -8,7 +8,6 @@ import (
 	"go/build"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -19,7 +18,7 @@ import (
 )
 
 // WritePackageInfo writes a series of package info files to the given file.
-func WritePackageInfo(importPath string, srcRoot, importconfig string, imports map[string]string, installPkgs []string, subrepo, module string, includeTests bool, w io.Writer) error {
+func WritePackageInfo(importPath string, srcRoot string, imports map[string]string, subrepo, module string, includeTests bool, w io.Writer) error {
 	// Discover all Go files in the module
 	goFiles := map[string][]string{}
 	module = modulePath(module, importPath)
@@ -35,30 +34,10 @@ func WritePackageInfo(importPath string, srcRoot, importconfig string, imports m
 		}
 		return nil
 	}
-	// Check install packages first
-	for _, pkg := range installPkgs {
-		if strings.Contains(pkg, "...") {
-			pkg = strings.TrimSuffix(pkg, "...")
-			if err := filepath.WalkDir(filepath.Join(srcRoot, pkg), walkDirFunc); err != nil {
-				return fmt.Errorf("failed to read module dir: %w", err)
-			}
-		} else {
-			dir := filepath.Join(srcRoot, pkg)
-			goFiles[dir] = append(goFiles[dir], filepath.Join(srcRoot, pkg))
-		}
+	if err := filepath.WalkDir(srcRoot, walkDirFunc); err != nil {
+		return fmt.Errorf("failed to read module dir: %w", err)
 	}
-	if len(installPkgs) == 0 {
-		if err := filepath.WalkDir(srcRoot, walkDirFunc); err != nil {
-			return fmt.Errorf("failed to read module dir: %w", err)
-		}
-	}
-	if importconfig != "" {
-		m, err := loadImportConfig(importconfig)
-		if err != nil {
-			return fmt.Errorf("failed to read importconfig: %w", err)
-		}
-		imports = m
-	}
+
 	pkgs := make([]*packages.Package, 0, len(goFiles))
 	for dir := range goFiles {
 		pkgDir := strings.TrimPrefix(strings.TrimPrefix(dir, srcRoot), "/")
@@ -80,13 +59,7 @@ func WritePackageInfo(importPath string, srcRoot, importconfig string, imports m
 		}
 		pkgs = append(pkgs, pkg)
 	}
-	// If we're doing the stdlib, limit it to just things in the importconfig (i.e. no cmd/ packages)
-	if importconfig != "" {
-		pkgs = slices.DeleteFunc(pkgs, func(pkg *packages.Package) bool {
-			_, present := imports[pkg.PkgPath]
-			return !present
-		})
-	}
+
 	// Vendor packages. They aren't identified by the original imports but we know what they are now.
 	vendorised := map[string]*packages.Package{}
 	for _, pkg := range pkgs {
@@ -173,26 +146,6 @@ func mappend(s []string, args ...[]string) []string {
 		s = append(s, arg...)
 	}
 	return s
-}
-
-// loadImportConfig reads the given importconfig file and produces a map of package name -> export path
-func loadImportConfig(filename string) (map[string]string, error) {
-	b, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	lines := strings.Split(string(b), "\n")
-	m := make(map[string]string, len(lines))
-	for _, line := range lines {
-		if strings.HasPrefix(line, "packagefile ") {
-			pkg, exportFile, found := strings.Cut(strings.TrimPrefix(line, "packagefile "), "=")
-			if !found {
-				return nil, fmt.Errorf("unknown syntax for line: %s", line)
-			}
-			m[pkg] = exportFile
-		}
-	}
-	return m, nil
 }
 
 // modulePath returns the import path for a module, or the given one if the module isn't set.

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -47,7 +47,7 @@ func WritePackageInfo(importPath string, srcRoot string, imports map[string]stri
 		} else if err != nil {
 			return fmt.Errorf("failed to import directory %s: %w", dir, err)
 		}
-		pkg := FromBuildPackage(bpkg, subrepo, module)
+		pkg := fromBuildPackage(bpkg, subrepo, module)
 
 		if subrepo != "" {
 			_, pkgPath, ok := strings.Cut(imports[pkg.PkgPath], pkg.PkgPath)
@@ -105,8 +105,7 @@ func buildPackage(
 	return bpkg, nil
 }
 
-// FromBuildPackage creates a packages Package from a build Package.
-func FromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Package {
+func fromBuildPackage(pkg *build.Package, subrepo, module string) *packages.Package {
 	goFiles := slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles)
 	imports := slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports)
 	name := pkg.Name

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -92,32 +92,32 @@ func buildPackage(
 }
 
 func fromBuildPackage(
-	pkg *build.Package,
+	bpkg *build.Package,
 	subrepo string,
 	module string,
 ) *packages.Package {
-	goFiles := make([]string, len(pkg.GoFiles)+len(pkg.TestGoFiles)+len(pkg.XTestGoFiles))
+	goFiles := make([]string, len(bpkg.GoFiles)+len(bpkg.TestGoFiles)+len(bpkg.XTestGoFiles))
 	compiledGoFiles := make([]string, len(goFiles))
-	for i, file := range slices.Concat(pkg.GoFiles, pkg.TestGoFiles, pkg.XTestGoFiles) {
+	for i, file := range slices.Concat(bpkg.GoFiles, bpkg.TestGoFiles, bpkg.XTestGoFiles) {
 		if subrepo != "" {
 			// this is fairly nasty... there must be a better way of getting it without the pkg/ prefix
-			dir := strings.TrimPrefix(pkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
+			dir := strings.TrimPrefix(bpkg.Dir, "pkg/"+runtime.GOOS+"_"+runtime.GOARCH)
 			dir = strings.TrimPrefix(strings.TrimPrefix(dir, "/"), module)
 			goFiles[i] = filepath.Join(subrepo, dir, file)
-			compiledGoFiles[i] = filepath.Join(pkg.Dir, file) // Stash this here for later
+			compiledGoFiles[i] = filepath.Join(bpkg.Dir, file) // Stash this here for later
 		} else {
-			goFiles[i] = filepath.Join(pkg.Dir, file)
-			compiledGoFiles[i] = filepath.Join(pkg.Dir, file)
+			goFiles[i] = filepath.Join(bpkg.Dir, file)
+			compiledGoFiles[i] = filepath.Join(bpkg.Dir, file)
 		}
 	}
-	imports := make(map[string]*packages.Package, len(pkg.Imports)+len(pkg.TestImports)+len(pkg.XTestImports))
-	for _, imp := range slices.Concat(pkg.Imports, pkg.TestImports, pkg.XTestImports) {
+	imports := make(map[string]*packages.Package, len(bpkg.Imports)+len(bpkg.TestImports)+len(bpkg.XTestImports))
+	for _, imp := range slices.Concat(bpkg.Imports, bpkg.TestImports, bpkg.XTestImports) {
 		imports[imp] = &packages.Package{ID: imp, PkgPath: imp}
 	}
 
-	name := pkg.Name
-	id := pkg.ImportPath
-	if len(pkg.XTestGoFiles) > 0 || len(pkg.XTestImports) > 0 {
+	name := bpkg.Name
+	id := bpkg.ImportPath
+	if len(bpkg.XTestGoFiles) > 0 || len(bpkg.XTestImports) > 0 {
 		// In please we may have an external test target and an internal test within the same please package.
 		// To ensure they have different go package import paths we appending to the name and id.
 		name += "_test"
@@ -129,8 +129,8 @@ func fromBuildPackage(
 		PkgPath:         id,
 		GoFiles:         goFiles,
 		CompiledGoFiles: compiledGoFiles,
-		OtherFiles:      slices.Concat(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
-		EmbedPatterns:   pkg.EmbedPatterns,
+		OtherFiles:      slices.Concat(bpkg.CFiles, bpkg.CXXFiles, bpkg.MFiles, bpkg.HFiles, bpkg.SFiles, bpkg.SwigFiles, bpkg.SwigCXXFiles, bpkg.SysoFiles),
+		EmbedPatterns:   bpkg.EmbedPatterns,
 		Imports:         imports,
 	}
 }

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -41,12 +41,14 @@ func WritePackageInfo(importPath string, srcRoot string, imports map[string]stri
 	pkgs := make([]*packages.Package, 0, len(goFiles))
 	for dir := range goFiles {
 		pkgDir := strings.TrimPrefix(strings.TrimPrefix(dir, srcRoot), "/")
-		pkg, err := createPackage(filepath.Join(importPath, pkgDir), dir, subrepo, module)
+		bpkg, err := buildPackage(filepath.Join(importPath, pkgDir), dir)
 		if _, ok := err.(*build.NoGoError); ok {
 			continue // Don't really care, this happens sometimes for modules
 		} else if err != nil {
 			return fmt.Errorf("failed to import directory %s: %w", dir, err)
 		}
+		pkg := FromBuildPackage(bpkg, subrepo, module)
+
 		if subrepo != "" {
 			_, pkgPath, ok := strings.Cut(imports[pkg.PkgPath], pkg.PkgPath)
 			if !ok {
@@ -83,7 +85,10 @@ func WritePackageInfo(importPath string, srcRoot string, imports map[string]stri
 	return e.Encode(pkgs)
 }
 
-func createPackage(pkgPath, pkgDir, subrepo, module string) (*packages.Package, error) {
+func buildPackage(
+	pkgPath string,
+	pkgDir string,
+) (*build.Package, error) {
 	if pkgDir == "" || pkgDir == "." {
 		// This happens when we're in the repo root, ImportDir refuses to read it for some reason.
 		path, err := filepath.Abs(pkgDir)
@@ -97,7 +102,7 @@ func createPackage(pkgPath, pkgDir, subrepo, module string) (*packages.Package, 
 		return nil, err
 	}
 	bpkg.ImportPath = pkgPath
-	return FromBuildPackage(bpkg, subrepo, module), nil
+	return bpkg, nil
 }
 
 // FromBuildPackage creates a packages Package from a build Package.

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -129,18 +129,10 @@ func fromBuildPackage(
 		PkgPath:         id,
 		GoFiles:         goFiles,
 		CompiledGoFiles: compiledGoFiles,
-		OtherFiles:      mappend(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
+		OtherFiles:      slices.Concat(pkg.CFiles, pkg.CXXFiles, pkg.MFiles, pkg.HFiles, pkg.SFiles, pkg.SwigFiles, pkg.SwigCXXFiles, pkg.SysoFiles),
 		EmbedPatterns:   pkg.EmbedPatterns,
 		Imports:         imports,
 	}
-}
-
-// mappend appends multiple slices together.
-func mappend(s []string, args ...[]string) []string {
-	for _, arg := range args {
-		s = append(s, arg...)
-	}
-	return s
 }
 
 // modulePath returns the import path for a module, or the given one if the module isn't set.

--- a/tools/please_go/packageinfo/packageinfo.go
+++ b/tools/please_go/packageinfo/packageinfo.go
@@ -62,20 +62,6 @@ func WritePackageInfo(importPath string, srcRoot string, imports map[string]stri
 		pkgs = append(pkgs, pkg)
 	}
 
-	// Vendor packages. They aren't identified by the original imports but we know what they are now.
-	vendorised := map[string]*packages.Package{}
-	for _, pkg := range pkgs {
-		if strings.HasPrefix(pkg.PkgPath, "vendor/") {
-			vendorised[strings.TrimPrefix(pkg.PkgPath, "vendor/")] = pkg
-		}
-	}
-	for _, pkg := range pkgs {
-		for k := range pkg.Imports {
-			if v, present := vendorised[k]; present {
-				pkg.Imports[k] = v
-			}
-		}
-	}
 	// Ensure output is deterministic
 	sort.Slice(pkgs, func(i, j int) bool {
 		return pkgs[i].ID < pkgs[j].ID

--- a/tools/please_go/packageinfo/packageinfo_test.go
+++ b/tools/please_go/packageinfo/packageinfo_test.go
@@ -1,0 +1,73 @@
+package packageinfo
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
+)
+
+func TestWritePackageInfo_Simple(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a simple package "foo"
+	fooDir := filepath.Join(tmpDir, "foo")
+	err := os.MkdirAll(fooDir, 0755)
+	require.NoError(t, err)
+
+	fooSrc := `package foo
+
+import "fmt"
+
+func Hello() {
+	fmt.Println("hello")
+}
+`
+	err = os.WriteFile(filepath.Join(fooDir, "foo.go"), []byte(fooSrc), 0644)
+	require.NoError(t, err)
+
+	imports := map[string]string{
+		"module/foo": "foo/foo.a",
+	}
+
+	var buf bytes.Buffer
+	err = WritePackageInfo(
+		"module/foo",
+		fooDir,
+		"",
+		imports,
+		nil,
+		"",
+		"",
+		false,
+		&buf,
+	)
+	require.NoError(t, err)
+
+	var pkgs []*packages.Package
+	err = json.Unmarshal(buf.Bytes(), &pkgs)
+	require.NoError(t, err)
+
+	expected := []*packages.Package{
+		{
+			ID:              "module/foo",
+			Name:            "foo",
+			PkgPath:         "module/foo",
+			GoFiles:         []string{filepath.Join(fooDir, "foo.go")},
+			CompiledGoFiles: []string{filepath.Join(fooDir, "foo.go")},
+			ExportFile:      "foo/foo.a",
+			Imports: map[string]*packages.Package{
+				"fmt": {
+					ID: "fmt",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, pkgs)
+}

--- a/tools/please_go/packageinfo/packageinfo_test.go
+++ b/tools/please_go/packageinfo/packageinfo_test.go
@@ -39,9 +39,7 @@ func Hello() {
 	err = WritePackageInfo(
 		"module/foo",
 		fooDir,
-		"",
 		imports,
-		nil,
 		"",
 		"",
 		false,

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -177,7 +177,7 @@ var subCommands = map[string]func() int{
 	},
 	"package_info": func() int {
 		pi := opts.PackageInfo
-		if err := packageinfo.WritePackageInfo(pi.ImportPath, pi.Pkg, "", pi.ImportMap, nil, pi.Subrepo, pi.Module, pi.IncludeTests, os.Stdout); err != nil {
+		if err := packageinfo.WritePackageInfo(pi.ImportPath, pi.Pkg, pi.ImportMap, pi.Subrepo, pi.Module, pi.IncludeTests, os.Stdout); err != nil {
 			log.Fatalf("failed to write package info: %s", err)
 		}
 		return 0

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/peterebden/go-cli-init/v5/flags"
-
 	"github.com/please-build/go-rules/tools/please_go/cover"
 	"github.com/please-build/go-rules/tools/please_go/embed"
 	"github.com/please-build/go-rules/tools/please_go/filter"
@@ -185,7 +184,7 @@ var subCommands = map[string]func() int{
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WriteModuleInfo(mi.ModulePath, mi.Srcs, mi.ImportConfig, nil, mi.Packages, "", "", false, os.Stdout); err != nil {
+		if err := packageinfo.WriteModuleInfo(mi.ModulePath, mi.Srcs, mi.ImportConfig, mi.Packages, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -185,7 +185,7 @@ var subCommands = map[string]func() int{
 	},
 	"module_info": func() int {
 		mi := opts.ModuleInfo
-		if err := packageinfo.WritePackageInfo(mi.ModulePath, mi.Srcs, mi.ImportConfig, nil, mi.Packages, "", "", false, os.Stdout); err != nil {
+		if err := packageinfo.WriteModuleInfo(mi.ModulePath, mi.Srcs, mi.ImportConfig, nil, mi.Packages, "", "", false, os.Stdout); err != nil {
 			log.Fatalf("failed to write module info: %s", err)
 		}
 		return 0


### PR DESCRIPTION
This change is a refactor.
It is in preparation for fixing issues #352 - #362.

I have attempted to keep the individual commits as small as possible. They should be significantly easier to review than the whole PR.

I have added some tests early on to reduce the risk of regressions with the refactoring. I have avoided adding test cases where the behaviour is currently buggy (e.g. I did not include a test case for external test packages given #362).

The primary aim of the refactor is to separate the codepaths for writing packageinfo for modules (i.e. the module_info command of please_go) and for stand-alone packages (i.e. the package_info command of please_go).

`module_info` is called for `go_module` and `go_stdlib` targets. `package_info` is called for all other types of targets.

These two groups of targets have very different characteristics:
1. `module_info` targets have many packages for a single target, whereas `package_info` targets should only return a single package.
2. `module_info` rules are only ever depended on, they do not have sources that need to be queried by the package driver directly. They are only ever included as dependencies.
3. `module_info` rules have their source code primarily built outside of please by standard go tooling. Therefore, they adhere to standard go package constraints that please does not enforce (e.g. one package per directory). They also use features of the go build tooling that please does not support for other types of targets (module vendoring).

These differences in characteristics heavily influence the way that I intend to handle the two types of packages when addressing the issues I have raised. I also believe the co-location of these two codepaths has contributed to the bugs that are present today (e.g. when attempting to introduce tests for `package_info` targets we accidentally introduced some bugs in the `module_info` targets).