### PR TITLE
Update please dep to 17.31.2

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-Version = >=17.31.0
+Version = >=17.31.2
 
 [build]
 hashcheckers = sha256
@@ -20,7 +20,7 @@ Target = //plugins:cc
 
 [Plugin "e2e"]
 Target = //plugins:e2e
-PleaseVersion = 17.31.0
+PleaseVersion = 17.31.2
 
 [PluginDefinition]
 Name = go


### PR DESCRIPTION
This ensures that the placeholder in go_test doesn't cause remote build failures