### PR TITLE
Make references to Go build defs relative to this repo

### DIFF
--- a/build_defs/cgo.build_defs
+++ b/build_defs/cgo.build_defs
@@ -1,4 +1,7 @@
-subinclude("///go//build_defs:go", "///cc//build_defs:c")
+subinclude(
+    "///cc//build_defs:c",
+    "//build_defs:go",
+)
 
 def cgo_library(
     name:str,

--- a/tools/please_go/generate/BUILD
+++ b/tools/please_go/generate/BUILD
@@ -1,4 +1,4 @@
-subinclude("///go//build_defs:go")
+subinclude("//build_defs:go")
 
 filegroup(
     name = "srcs",

--- a/tools/please_go/generate/gomoddeps/BUILD
+++ b/tools/please_go/generate/gomoddeps/BUILD
@@ -1,4 +1,4 @@
-subinclude("///go//build_defs:go")
+subinclude("//build_defs:go")
 
 filegroup(
     name = "srcs",


### PR DESCRIPTION
This is the go-rules plugin, so `///go//build_defs` should in fact be `//build_defs`.