### PR TITLE
Generate `definitions` parameter for Go binary targets

### DIFF
--- a/tools/please_go/generate/generate.go
+++ b/tools/please_go/generate/generate.go
@@ -30,13 +30,14 @@ type Generate struct {
 	replace            map[string]string
 	knownImportTargets map[string]string // cache these so we don't end up looping over all the modules for every import
 	thirdPartyFolder   string
+	definitions        []string
 	install            []string
 	labels             []string
 	largePackages      []string
 	licences           []string
 }
 
-func New(srcRoot, thirdPartyFolder, hostModFile, module, version, subrepo string, buildFileNames, moduleDeps, install, buildTags, labels, largePackages, licences []string) *Generate {
+func New(srcRoot, thirdPartyFolder, hostModFile, module, version, subrepo string, buildFileNames, moduleDeps, install, buildTags, definitions, labels, largePackages, licences []string) *Generate {
 	moduleArg := module
 	if version != "" {
 		moduleArg += "@" + version
@@ -54,6 +55,7 @@ func New(srcRoot, thirdPartyFolder, hostModFile, module, version, subrepo string
 		knownImportTargets: map[string]string{},
 		thirdPartyFolder:   thirdPartyFolder,
 		install:            install,
+		definitions:        definitions,
 		moduleName:         module,
 		moduleArg:          moduleArg,
 		subrepo:            subrepo,
@@ -454,14 +456,20 @@ func (g *Generate) ruleForPackage(pkg *build.Package, dir string) *Rule {
 	}
 
 	name := nameForLibInPkg(g.moduleName, trimPath(dir, g.srcRoot))
+	kind := packageKind(pkg)
 	deps := g.depTargets(pkg.Imports)
 	if len(pkg.IgnoredOtherFiles) != 0 {
 		deps = append(deps, ":a_files")
 	}
 
+	var definitions []string
+	if kind == "cgo_binary" || kind == "go_binary" {
+		definitions = g.definitions
+	}
+
 	return &Rule{
 		name:           name,
-		kind:           packageKind(pkg),
+		kind:           kind,
 		srcs:           pkg.GoFiles,
 		module:         g.moduleArg,
 		subrepo:        g.subrepo,
@@ -469,6 +477,7 @@ func (g *Generate) ruleForPackage(pkg *build.Package, dir string) *Rule {
 		cSrcs:          pkg.CFiles,
 		compilerFlags:  pkg.CgoCFLAGS,
 		linkerFlags:    orderLinkerFlags(pkg.CgoLDFLAGS),
+		definitions:    definitions,
 		pkgConfigs:     pkg.CgoPkgConfig,
 		asmFiles:       pkg.SFiles,
 		hdrs:           pkg.HFiles,

--- a/tools/please_go/generate/rules.go
+++ b/tools/please_go/generate/rules.go
@@ -11,6 +11,7 @@ type Rule struct {
 	cgoSrcs        []string
 	cSrcs          []string
 	compilerFlags  []string
+	definitions    []string
 	linkerFlags    []string
 	pkgConfigs     []string
 	asmFiles       []string
@@ -42,6 +43,9 @@ func populateRule(r *build.Rule, targetState *Rule) {
 	}
 	if len(targetState.linkerFlags) > 0 {
 		r.SetAttr("linker_flags", NewStringList(targetState.linkerFlags))
+	}
+	if len(targetState.definitions) > 0 {
+		r.SetAttr("definitions", NewStringList(targetState.definitions))
 	}
 	if len(targetState.hdrs) > 0 {
 		r.SetAttr("hdrs", NewStringList(targetState.hdrs))

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -94,7 +94,7 @@ var opts = struct {
 		Version          string   `long:"version" description:"The version of the current module"`
 		Install          []string `long:"install" description:"The packages to add to the :install alias"`
 		BuildTags        []string `long:"build_tag" description:"Any build tags to apply to the build"`
-		Definitions      []string `short:"D" long:"definition" value-name:"[IMPORTPATH].[NAME]=[VALUE]" description:"Element to insert into \"definitions\" parameter when generating Go binary targets"`
+		Definitions      []string `long:"definition" value-name:"[IMPORTPATH].[NAME]=[VALUE]" description:"Element to insert into \"definitions\" parameter when generating Go binary targets"`
 		Subrepo          string   `long:"subrepo" description:"The subrepo root to output into"`
 		Licences         []string `long:"licence" description:"The licences under which the module is released"`
 		Labels           []string `long:"label" description:"Additional labels to attach to subrepo targets"`

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -94,6 +94,7 @@ var opts = struct {
 		Version          string   `long:"version" description:"The version of the current module"`
 		Install          []string `long:"install" description:"The packages to add to the :install alias"`
 		BuildTags        []string `long:"build_tag" description:"Any build tags to apply to the build"`
+		Definitions      []string `short:"D" long:"definition" value-name:"[IMPORTPATH].[NAME]=[VALUE]" description:"Element to insert into \"definitions\" parameter when generating Go binary targets"`
 		Subrepo          string   `long:"subrepo" description:"The subrepo root to output into"`
 		Licences         []string `long:"licence" description:"The licences under which the module is released"`
 		Labels           []string `long:"label" description:"Additional labels to attach to subrepo targets"`
@@ -170,7 +171,22 @@ var subCommands = map[string]func() int{
 	},
 	"generate": func() int {
 		gen := opts.Generate
-		g := generate.New(gen.SrcRoot, gen.ThirdPartyFolder, gen.ModFile, gen.Module, gen.Version, gen.Subrepo, []string{"BUILD", "BUILD.plz"}, gen.Args.Requirements, gen.Install, gen.BuildTags, gen.Labels, gen.LargePackages, gen.Licences)
+		g := generate.New(
+			gen.SrcRoot,
+			gen.ThirdPartyFolder,
+			gen.ModFile,
+			gen.Module,
+			gen.Version,
+			gen.Subrepo,
+			[]string{"BUILD", "BUILD.plz"},
+			gen.Args.Requirements,
+			gen.Install,
+			gen.BuildTags,
+			gen.Definitions,
+			gen.Labels,
+			gen.LargePackages,
+			gen.Licences,
+		)
 		if err := g.Generate(); err != nil {
 			log.Fatalf("failed to generate go rules: %v", err)
 		}


### PR DESCRIPTION
In `please_go generate`, pass through the given values of `-D`/`--definition` to the `definitions` parameter when generating `go_binary` and `cgo_binary` targets.