### PR TITLE
Add `definitions` parameter to `go_repo`

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1803,7 +1803,7 @@ def _go_library_cmds(name, import_path:str="", complete=True, all_srcs=False, co
     return cmds, tools
 
 
-def _go_linker_defs(definitions):
+def _go_linker_defs(definitions:str|list|dict):
     """Formats a string, list or dictionary of Go linker definitions as a list of values that can each
     be passed as a value of -X to the Go linker (or as a value of --definition to `please_go generate`)."""
     if definitions is None:

--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1277,7 +1277,8 @@ def _module_rule_name(module):
 
 def go_repo(module: str, version:str='', download:str=None, name:str=None, install:list=[], requirements:list=[],
             licences:list=None, patch:list=None, visibility:list=["PUBLIC"], deps:list=[], build_tags:list=CONFIG.GO.BUILD_TAGS,
-            third_party_path:str="third_party/go", strip:list=None, labels:list=[], large_packages:list=[]):
+            third_party_path:str="third_party/go", strip:list=None, definitions:str|list|dict=None, labels:list=[],
+            large_packages:list=[]):
     """Adds a third party go module to the build graph as a subrepo. This is designed to be closer to how the `go.mod`
     file works, requiring only the module name and version to be specified. Unlike go_module, each package is compiled
     individually, and dependencies between packages are inferred by convention.
@@ -1314,6 +1315,9 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
       build_tags (list): Build tags to pass to the Go compiler.
       third_party_path (str): Optional path of third_party directory.
       strip (list): A list of directories to strip from the repo
+      definitions (str | list | dict): Go linker definitions to set on go_binary and cgo_binary targets generated in
+                                       the subrepo. Refer to "definitions" in go_binary for further details about what
+                                       this does.
       labels (list): Labels for this rule.
       large_packages (list): List of relative package names which should be marked as large in the
                              generated go_library rules (i.e. packages which have large number of
@@ -1347,6 +1351,8 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
     else:
         modFileArg = ""
 
+    def_args = " ".join([f'--definition "{d}"' for d in _go_linker_defs(definitions)])
+
     labels += ["go_module_path:" + module]
     if version:
         labels += [f"go_module:{module}@{version}"]
@@ -1368,7 +1374,21 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
         "find $SRCS_DOWNLOAD -name BUILD -delete",
         f"mkdir -p $(dirname {pkgRoot})",
         f"mv $SRCS_DOWNLOAD {pkgRoot}",
-        f"$TOOL generate {modFileArg} --module {module} --version '{version}' {build_tag_args} {label_args} {large_package_args} --src_root={pkgRoot} --third_part_folder='{third_party_path}' --subrepo '{pkg_name}/{subrepo_name}' {install_args} {requirements} {licence_args}",
+        f"$TOOL generate " + " ".join([
+            modFileArg,
+            f"--module {module}",
+            f"--version '{version}'",
+            build_tag_args,
+            def_args,
+            label_args,
+            large_package_args,
+            f"--src_root={pkgRoot}",
+            f"--third_part_folder='{third_party_path}'",
+            f"--subrepo '{pkg_name}/{subrepo_name}'",
+            install_args,
+            requirements,
+            licence_args,
+        ]),
         f"mv {pkgRoot} $OUT",
     ]
     cmd = " && ".join(cmds)
@@ -1783,6 +1803,19 @@ def _go_library_cmds(name, import_path:str="", complete=True, all_srcs=False, co
     return cmds, tools
 
 
+def _go_linker_defs(definitions):
+    """Formats a string, list or dictionary of Go linker definitions as a list of values that can each
+    be passed as a value of -X to the Go linker (or as a value of --definition to `please_go generate`)."""
+    if definitions is None:
+        return []
+    if isinstance(definitions, str):
+        return [f"{definitions}"]
+    if isinstance(definitions, list):
+        return [f"{d}" for d in definitions]
+    if isinstance(definitions, dict):
+        return [k if v is None else f"{k}={v}" for k, v in sorted(definitions.items())]
+
+
 def _go_binary_cmds(name, static=False, ldflags='', pkg_config='', definitions=None, gcov=False, split_debug=False, strip=None, test=False):
     """Returns the commands to run for linking a Go binary."""
 
@@ -1794,15 +1827,7 @@ def _go_binary_cmds(name, static=False, ldflags='', pkg_config='', definitions=N
         gen_import_cfg += ' && ' + _generate_pkg_import_cfg_cmd(name, "goroot.importconfig", '"$GOROOT"')
     gen_import_cfg += ' && ' + _aggregate_import_cfg_cmd()
 
-    linkerdefs = []
-    if definitions is None:
-        pass
-    elif isinstance(definitions, str):
-        linkerdefs += [f'{definitions}']
-    elif isinstance(definitions, list):
-        linkerdefs += [f'{linkerdef}' for linkerdef in definitions]
-    elif isinstance(definitions, dict):
-        linkerdefs = [k if v is None else f'{k}={v}' for k, v in sorted(definitions.items())]
+    linkerdefs = _go_linker_defs(definitions)
     if test:
         linkerdefs += ["testing.testBinary=1"]
 

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -1,7 +1,7 @@
 plugin_repo(
     name = "e2e",
     plugin = "plugin-integration-testing",
-    revision = "v1.0.3",
+    revision = "v1.1.0",
 )
 
 plugin_repo(

--- a/test/go_repo_definitions/BUILD
+++ b/test/go_repo_definitions/BUILD
@@ -1,0 +1,10 @@
+subinclude("//test/build_defs:e2e")
+
+please_repo_e2e_test(
+    name = "go_repo_definitions_test",
+    expected_output = {
+        "test.out": "go_repo value",
+    },
+    plz_command = "plz run ///third_party/go/test.please.build_module//cmd > test.out",
+    repo = "test_repo",
+)

--- a/test/go_repo_definitions/test_repo/.plzconfig
+++ b/test/go_repo_definitions/test_repo/.plzconfig
@@ -1,0 +1,9 @@
+[Parse]
+BuildFileName = BUILD_FILE
+BuildFileName = BUILD
+
+[Plugin "go"]
+Target = //plugins:go
+PleaseGoTool = <pleasegotool>
+GoTool = <gotool>
+Stdlib = //third_party/go:std

--- a/test/go_repo_definitions/test_repo/plugins/BUILD_FILE
+++ b/test/go_repo_definitions/test_repo/plugins/BUILD_FILE
@@ -1,0 +1,4 @@
+plugin_repo(
+    name = "go",
+    revision = "master",
+)

--- a/test/go_repo_definitions/test_repo/third_party/go/BUILD_FILE
+++ b/test/go_repo_definitions/test_repo/third_party/go/BUILD_FILE
@@ -1,0 +1,15 @@
+subinclude("///go//build_defs:go")
+
+go_stdlib(
+    name = "std",
+)
+
+go_repo(
+    name = "module",
+    definitions = {
+        "test.please.build/module/string.str": "go_repo value",
+    },
+    download = "module",
+    module = "test.please.build/module",
+    version = "v1.0.0",
+)

--- a/test/go_repo_definitions/test_repo/third_party/go/module/cmd/main.go
+++ b/test/go_repo_definitions/test_repo/third_party/go/module/cmd/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	tstring "test.please.build/module/string"
+)
+
+func main() {
+	fmt.Println(tstring.GetString())
+}

--- a/test/go_repo_definitions/test_repo/third_party/go/module/go.mod
+++ b/test/go_repo_definitions/test_repo/third_party/go/module/go.mod
@@ -1,0 +1,3 @@
+module test.please.build/module
+
+go 1.26.0

--- a/test/go_repo_definitions/test_repo/third_party/go/module/string/string.go
+++ b/test/go_repo_definitions/test_repo/third_party/go/module/string/string.go
@@ -1,0 +1,7 @@
+package string
+
+var str = "hardcoded value"
+
+func GetString() string {
+	return str
+}

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,11 +1,11 @@
-VERSION = "1.24.1"
+VERSION = "1.25.0"
 
 hashes = {
-    "darwin_amd64": "0b00408859b67e48aabdf632bc7debf9fb1016896725bc7fe3e8b527ce89720a",
-    "darwin_arm64": "192076228d266b1ec42b56b8d0da50171263b8f684d4e838e7f53c32d8c9a256",
-    "freebsd_amd64": "3a3a9e7e80c9f037d7f184065adb0b79d1747fc4d3f0f0d88a3e1aea8de27f37",
-    "linux_amd64": "f448e1f23438821e750054240cfc897b1a8baffdc2a53adda10f879d3bdd0dc9",
-    "linux_arm64": "9b7d5c4efe577fcf2020f7a500f3508660b313ecf0b7473768a2a131169268a2",
+    "darwin_amd64": "d18b242735aef9fc48a4d1e41ef14d57c2de0a185661954851b0cf09a4beac15",
+    "darwin_arm64": "33a29068894bc10e245281faa55957c785e20844bf0362f4eebdba3f375ee464",
+    "freebsd_amd64": "ea35c5d1d605ba680ba82d467e718be9d8d6b5ce1fa2a144a3824b2d2bd323cc",
+    "linux_amd64": "86b40c9450e5ee15ab08e7aa3ec8e73068b7626f787088f91e96c5e35c0b7cc7",
+    "linux_arm64": "69e6ae65cdaadb3bcc1e413ef38b147b97cdb9542e86f0698958394487142eb3",
 }
 
 for a, h in hashes.items():


### PR DESCRIPTION
This sets the given value of `definitions` on `go_binary` and `cgo_binary` targets generated within the subrepo. This is useful for replicating the behaviour of third-party binary build pipelines in Please (e.g. by allowing version strings to be set dynamically during linking).