### PR TITLE
`go_repo`: rename `third_party_path` to `deps_path`

### DIFF
--- a/build_defs/go.build_defs
+++ b/build_defs/go.build_defs
@@ -1277,7 +1277,7 @@ def _module_rule_name(module):
 
 def go_repo(module: str, version:str='', download:str=None, name:str=None, install:list=[], requirements:list=[],
             licences:list=None, patch:list=None, visibility:list=["PUBLIC"], deps:list=[], build_tags:list=CONFIG.GO.BUILD_TAGS,
-            third_party_path:str="third_party/go", strip:list=None, definitions:str|list|dict=None, labels:list=[],
+            deps_path:str&third_party_path="third_party/go", strip:list=None, definitions:str|list|dict=None, labels:list=[],
             large_packages:list=[]):
     """Adds a third party go module to the build graph as a subrepo. This is designed to be closer to how the `go.mod`
     file works, requiring only the module name and version to be specified. Unlike go_module, each package is compiled
@@ -1313,7 +1313,8 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
       deps (list): Any deps on other rule kinds that provide packages, for example go_module(). This can be used to
                    migrate to go_repo incrementally, one module at a time.
       build_tags (list): Build tags to pass to the Go compiler.
-      third_party_path (str): Optional path of third_party directory.
+      deps_path (str): Assume third-party Go modules are defined in this package (without the leading //) when generating
+                       build targets in the module's subrepo.
       strip (list): A list of directories to strip from the repo
       definitions (str | list | dict): Go linker definitions to set on go_binary and cgo_binary targets generated in
                                        the subrepo. Refer to "definitions" in go_binary for further details about what
@@ -1383,7 +1384,7 @@ def go_repo(module: str, version:str='', download:str=None, name:str=None, insta
             label_args,
             large_package_args,
             f"--src_root={pkgRoot}",
-            f"--third_part_folder='{third_party_path}'",
+            f"--deps_path='{deps_path}'",
             f"--subrepo '{pkg_name}/{subrepo_name}'",
             install_args,
             requirements,

--- a/tools/please_go/generate/generate.go
+++ b/tools/please_go/generate/generate.go
@@ -29,7 +29,7 @@ type Generate struct {
 	moduleDeps         []string
 	replace            map[string]string
 	knownImportTargets map[string]string // cache these so we don't end up looping over all the modules for every import
-	thirdPartyFolder   string
+	depsPath           string
 	definitions        []string
 	install            []string
 	labels             []string
@@ -37,7 +37,7 @@ type Generate struct {
 	licences           []string
 }
 
-func New(srcRoot, thirdPartyFolder, hostModFile, module, version, subrepo string, buildFileNames, moduleDeps, install, buildTags, definitions, labels, largePackages, licences []string) *Generate {
+func New(srcRoot, depsPath, hostModFile, module, version, subrepo string, buildFileNames, moduleDeps, install, buildTags, definitions, labels, largePackages, licences []string) *Generate {
 	moduleArg := module
 	if version != "" {
 		moduleArg += "@" + version
@@ -53,7 +53,7 @@ func New(srcRoot, thirdPartyFolder, hostModFile, module, version, subrepo string
 		moduleDeps:         moduleDeps,
 		hostModFile:        hostModFile,
 		knownImportTargets: map[string]string{},
-		thirdPartyFolder:   thirdPartyFolder,
+		depsPath:           depsPath,
 		install:            install,
 		definitions:        definitions,
 		moduleName:         module,
@@ -590,7 +590,7 @@ func (g *Generate) subrepoName(module string) string {
 	if g.moduleName == module {
 		return ""
 	}
-	return filepath.Join(g.thirdPartyFolder, strings.ReplaceAll(module, "/", "_"))
+	return filepath.Join(g.depsPath, strings.ReplaceAll(module, "/", "_"))
 }
 
 func (g *Generate) libTargetForBuildPackage(i string) (string, error) {

--- a/tools/please_go/generate/generate_test.go
+++ b/tools/please_go/generate/generate_test.go
@@ -148,7 +148,7 @@ func TestDepTarget(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := &Generate{
 				moduleName:         "github.com/this/module",
-				thirdPartyFolder:   "third_party/go",
+				depsPath:           "third_party/go",
 				replace:            map[string]string{},
 				knownImportTargets: map[string]string{},
 				moduleDeps:         test.deps,

--- a/tools/please_go/please_go.go
+++ b/tools/please_go/please_go.go
@@ -87,20 +87,20 @@ var opts = struct {
 		Packages     []string `short:"p" long:"packages" description:"Packages to include in the module"`
 	} `command:"module_info" alias:"m" description:"Creates an info file about a series of packages in a go_module"`
 	Generate struct {
-		SrcRoot          string   `short:"r" long:"src_root" description:"The src root of the module to inspect"`
-		ImportPath       string   `long:"import_path" description:"overrides the module's import path. If not set, the import path from the go.mod will be used.'"`
-		ThirdPartyFolder string   `short:"t" long:"third_part_folder" description:"The folder containing the third party subrepos" default:"third_party/go"`
-		ModFile          string   `long:"mod_file" description:"Path to the host repo mod file to use to resolve dependencies against (dependencies will be resolved against the module as well if it exists)"`
-		Module           string   `long:"module" description:"The name of the current module"`
-		Version          string   `long:"version" description:"The version of the current module"`
-		Install          []string `long:"install" description:"The packages to add to the :install alias"`
-		BuildTags        []string `long:"build_tag" description:"Any build tags to apply to the build"`
-		Definitions      []string `long:"definition" value-name:"[IMPORTPATH].[NAME]=[VALUE]" description:"Element to insert into \"definitions\" parameter when generating Go binary targets"`
-		Subrepo          string   `long:"subrepo" description:"The subrepo root to output into"`
-		Licences         []string `long:"licence" description:"The licences under which the module is released"`
-		Labels           []string `long:"label" description:"Additional labels to attach to subrepo targets"`
-		LargePackages    []string `long:"large_package" description:"Relative names of packages which have lots of input files (meaning the go_library target should be marked as large)"`
-		Args             struct {
+		SrcRoot       string   `short:"r" long:"src_root" description:"The src root of the module to inspect"`
+		ImportPath    string   `long:"import_path" description:"overrides the module's import path. If not set, the import path from the go.mod will be used.'"`
+		DepsPath      string   `long:"deps_path" value-name:"[PKG]" description:"Assume third-party Go modules are defined in PKG when generating dependency target names" default:"third_party/go"`
+		ModFile       string   `long:"mod_file" description:"Path to the host repo mod file to use to resolve dependencies against (dependencies will be resolved against the module as well if it exists)"`
+		Module        string   `long:"module" description:"The name of the current module"`
+		Version       string   `long:"version" description:"The version of the current module"`
+		Install       []string `long:"install" description:"The packages to add to the :install alias"`
+		BuildTags     []string `long:"build_tag" description:"Any build tags to apply to the build"`
+		Definitions   []string `long:"definition" value-name:"[IMPORTPATH].[NAME]=[VALUE]" description:"Element to insert into \"definitions\" parameter when generating Go binary targets"`
+		Subrepo       string   `long:"subrepo" description:"The subrepo root to output into"`
+		Licences      []string `long:"licence" description:"The licences under which the module is released"`
+		Labels        []string `long:"label" description:"Additional labels to attach to subrepo targets"`
+		LargePackages []string `long:"large_package" description:"Relative names of packages which have lots of input files (meaning the go_library target should be marked as large)"`
+		Args          struct {
 			Requirements []string `positional-arg-name:"requirements" description:"Any module requirements not included in the go.mod"`
 		} `positional-args:"true"`
 	} `command:"generate" alias:"g" description:"Generate build targets for a Go module"`
@@ -174,7 +174,7 @@ var subCommands = map[string]func() int{
 		gen := opts.Generate
 		g := generate.New(
 			gen.SrcRoot,
-			gen.ThirdPartyFolder,
+			gen.DepsPath,
 			gen.ModFile,
 			gen.Module,
 			gen.Version,


### PR DESCRIPTION
The purpose of `go_repo`'s `third_party_path` parameter isn't clear without a detailed reading of the please_go source code: it is the name of the package assumed to contain definitions of third-party Go module dependencies for the module whose targets are being generated. Rename the parameter to `deps_path` (while maintaining an alias for `third_party_path` for backwards compatibility) to make its purpose explicit.