### PR TITLE
GHA: upgrade actions that still depend on Node.js 20

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Run tests
         run: ./pleasew test -p -v notice --log_file plz-out/log/test.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs
           path: plz-out/log
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Run tests with coverage
         run: ./pleasew cover -p -v notice --nocoverage_report --log_file plz-out/log/test_coverage.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage_logs
           path: plz-out/log
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Run tests with separate Go tools
         run: ./pleasew cover -p -v notice --nocoverage_report --log_file plz-out/log/test_tools.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tools_logs
           path: plz-out/log
@@ -44,12 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Build with debug configuration
         run: ./pleasew build -c dbg -p -v notice --log_file plz-out/log/test_debug.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug_logs
           path: plz-out/log
@@ -63,7 +63,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
       - name: Build please_go
         run: ./pleasew build //tools/please_go
       - name: Build


### PR DESCRIPTION
Node.js 20 has long been deprecated on GitHub's hosted runners and will likely be removed soon - upgrade the actions that depend on it to versions that run on Node.js 24.